### PR TITLE
Fix HEIC extension check in load_image

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -8,7 +8,7 @@ from rembg import remove
 # HEIC対応読み込み
 def load_image(path):
     ext = os.path.splitext(path)[-1].lower()
-    if ext == ".haeic":
+    if ext == ".heic":
         heif_file = pillow_heif.read_heif(path)
         img = Image.frombytes(heif_file.mode, heif_file.size, heif_file.data, "raw")
         return cv2.cvtColor(np.array(img), cv2.COLOR_RGB2BGR)


### PR DESCRIPTION
## Summary
- fix typo in `.heic` extension detection for HEIC decoding

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896bc90ad6c832fa4d0039a493e7e21