### PR TITLE
Handle missing width measurements gracefully

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -62,12 +62,18 @@ def measure_clothes(image, cm_per_pixel):
     # 肩幅（上から10%の位置での幅）
     shoulder_y = y + int(h * 0.1)
     shoulder_line = gray[shoulder_y:shoulder_y+5, x:x+w]
-    shoulder_width = np.max(np.where(shoulder_line < 128)) - np.min(np.where(shoulder_line < 128))
+    shoulder_indices = np.where(shoulder_line < 128)[1]
+    if shoulder_indices.size == 0:
+        raise ValueError("肩幅を計測できませんでした（肩ラインに有効なピクセルが見つかりません）。")
+    shoulder_width = shoulder_indices.max() - shoulder_indices.min()
 
     # 身幅（胸あたり＝上から30%）
     chest_y = y + int(h * 0.3)
     chest_line = gray[chest_y:chest_y+5, x:x+w]
-    chest_width = np.max(np.where(chest_line < 128)) - np.min(np.where(chest_line < 128))
+    chest_indices = np.where(chest_line < 128)[1]
+    if chest_indices.size == 0:
+        raise ValueError("身幅を計測できませんでした（胸ラインに有効なピクセルが見つかりません）。")
+    chest_width = chest_indices.max() - chest_indices.min()
 
     # 袖丈（肩端から袖端まで）
     sleeve_length = (shoulder_width - chest_width) / 2
@@ -108,7 +114,11 @@ if cm_per_pixel is None:
 img_no_bg = remove_background(img)
 
 # 服計測
-contour, measurements = measure_clothes(img_no_bg, cm_per_pixel)
+try:
+    contour, measurements = measure_clothes(img_no_bg, cm_per_pixel)
+except ValueError as e:
+    print(f"計測エラー: {e}")
+    exit()
 if contour is None:
     print("服が検出できません。")
     exit()
@@ -123,5 +133,3 @@ cv2.drawContours(img_with_text, [contour], -1, (255, 0, 0), 2)
 # 保存
 cv2.imwrite("clothes_with_measurements.jpg", img_with_text)
 print("寸法入り画像を保存しました → clothes_with_measurements.jpg")
-# calculate_the_clothing
-calculate the clothing


### PR DESCRIPTION
## Summary
- Guard shoulder and chest width calculations against empty detections and raise clear errors.
- Surface measurement errors to the user with friendly messages when widths cannot be derived.

## Testing
- `python -m py_compile Clothing`
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896bc973b34832f95bea325178f94bc