### PR TITLE
Compute shoulder and chest widths from clothing image

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -62,12 +62,27 @@ def measure_clothes(image, cm_per_pixel):
     # 肩幅（上から10%の位置での幅）
     shoulder_y = y + int(h * 0.1)
     shoulder_line = gray[shoulder_y:shoulder_y+5, x:x+w]
-
+    shoulder_points = cv2.findNonZero(shoulder_line)
+    if shoulder_points is None:
+        raise ValueError("Shoulder line not detected")
+    shoulder_xs = shoulder_points[:, 0, 0]
+    shoulder_ys = shoulder_points[:, 0, 1]
+    left_idx = np.argmin(shoulder_xs)
+    right_idx = np.argmax(shoulder_xs)
+    left_shoulder = (x + shoulder_xs[left_idx], shoulder_y + shoulder_ys[left_idx])
+    right_shoulder = (x + shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
+    shoulder_width = right_shoulder[0] - left_shoulder[0]
 
     # 身幅（胸あたり＝上から30%）
     chest_y = y + int(h * 0.3)
     chest_line = gray[chest_y:chest_y+5, x:x+w]
-
+    chest_points = cv2.findNonZero(chest_line)
+    if chest_points is None:
+        raise ValueError("Chest line not detected")
+    chest_xs = chest_points[:, 0, 0]
+    left_chest = x + chest_xs.min()
+    right_chest = x + chest_xs.max()
+    chest_width = right_chest - left_chest
 
     # 袖端（輪郭の左右端）
     left_sleeve_end = tuple(clothes_contour[clothes_contour[:, :, 0].argmin()][0])


### PR DESCRIPTION
## Summary
- Calculate shoulder width by detecting left and right shoulder points from nonzero pixels.
- Determine chest width using edge detection of chest line.
- Ensure measurement variables are defined before use and in output.

## Testing
- `python -m py_compile Clothing`


------
https://chatgpt.com/codex/tasks/task_e_6896c1ab82d0832f85e39d820ffd0a11