### PR TITLE
左袖丈・右袖丈の計測値を削除

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -101,8 +101,6 @@ def measure_clothes(image, cm_per_pixel):
         "身幅": chest_width * cm_per_pixel,
         "身丈": body_length * cm_per_pixel,
         "袖丈": sleeve_length * cm_per_pixel,
-        "左袖丈": left_sleeve_length * cm_per_pixel,
-        "右袖丈": right_sleeve_length * cm_per_pixel,
     }
     return clothes_contour, measures
 


### PR DESCRIPTION
## Summary
- `measure_clothes` の計測結果から「左袖丈」「右袖丈」を削除
- 描画処理は計測辞書をループするため、該当項目は描画されないことを確認

## Testing
- `python` スクリプトを実行しようとしたが `cv2`/`numpy` が見つからず失敗
- `pip install opencv-python-headless numpy` を試みたがネットワーク制限により失敗
- 代替として計測辞書を手動生成し、"肩幅" "身幅" "身丈" "袖丈" のみ出力されることを確認

------
https://chatgpt.com/codex/tasks/task_e_6896c673d4fc832f9c8fed09a940e077