### PR TITLE
Add morphological closing and convex hull smoothing

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -51,13 +51,18 @@ def remove_background(image):
 def measure_clothes(image, cm_per_pixel):
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     _, thresh = cv2.threshold(gray, 10, 255, cv2.THRESH_BINARY)
+    # ノイズ除去のためのクロージング処理
+    kernel = np.ones((5, 5), np.uint8)
+    thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
     contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
     if not contours:
         return None, {}
 
     clothes_contour = max(contours, key=cv2.contourArea)
-    x, y, w, h = cv2.boundingRect(clothes_contour)
+    # 凸包で輪郭を滑らかにする
+    hull = cv2.convexHull(clothes_contour)
+    x, y, w, h = cv2.boundingRect(hull)
 
     # 肩幅（上から10%の位置での幅）
     shoulder_y = y + int(h * 0.1)
@@ -84,17 +89,19 @@ def measure_clothes(image, cm_per_pixel):
     right_chest = x + chest_xs.max()
     chest_width = right_chest - left_chest
 
-    # 袖端（輪郭の左右端）
-    left_sleeve_end = tuple(clothes_contour[clothes_contour[:, :, 0].argmin()][0])
-    right_sleeve_end = tuple(clothes_contour[clothes_contour[:, :, 0].argmax()][0])
+    # 袖端（凸包の左右端）
+    left_sleeve_end = tuple(hull[hull[:, :, 0].argmin()][0])
+    right_sleeve_end = tuple(hull[hull[:, :, 0].argmax()][0])
 
     # 肩端から袖端までの距離
     left_sleeve_length = np.linalg.norm(np.array(left_shoulder) - np.array(left_sleeve_end))
     right_sleeve_length = np.linalg.norm(np.array(right_shoulder) - np.array(right_sleeve_end))
     sleeve_length = (left_sleeve_length + right_sleeve_length) / 2
 
-    # 身丈
-    body_length = h
+    # 身丈（凸包の上下端）
+    top_point = hull[hull[:, :, 1].argmin()][0]
+    bottom_point = hull[hull[:, :, 1].argmax()][0]
+    body_length = bottom_point[1] - top_point[1]
 
     measures = {
         "肩幅": shoulder_width * cm_per_pixel,
@@ -104,7 +111,7 @@ def measure_clothes(image, cm_per_pixel):
         "左袖丈": left_sleeve_length * cm_per_pixel,
         "右袖丈": right_sleeve_length * cm_per_pixel,
     }
-    return clothes_contour, measures
+    return hull, measures
 
 # 画像に寸法描画
 def draw_measurements_on_image(image, measurements):

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -1,0 +1,33 @@
+import os
+import importlib.util
+import numpy as np
+import cv2
+
+# Load Clothing module from the script without extension
+MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
+spec = importlib.util.spec_from_file_location('clothing', MODULE_PATH)
+clothing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clothing)
+
+
+def create_test_image():
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    # body
+    cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
+    # sleeves (triangular) to give unique endpoints
+    left_sleeve = np.array([[80, 70], [30, 90], [80, 110]], np.int32)
+    right_sleeve = np.array([[120, 70], [170, 90], [120, 110]], np.int32)
+    cv2.fillConvexPoly(img, left_sleeve, (255, 255, 255))
+    cv2.fillConvexPoly(img, right_sleeve, (255, 255, 255))
+    return img
+
+
+def test_measure_clothes_lengths():
+    img = create_test_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    # Expected body length between top y=50 and bottom y=180
+    assert abs(measures['身丈'] - 130) < 1.0
+    # Expected sleeve length from shoulder (80,63) to sleeve end (30,90)
+    expected_sleeve = np.hypot(80 - 30, 63 - 90)
+    assert abs(measures['袖丈'] - expected_sleeve) < 1.0


### PR DESCRIPTION
## Summary
- Reduce noise with morphological closing in `measure_clothes`
- Smooth contour via convex hull and recompute body and sleeve endpoints
- Add synthetic-image test verifying body and sleeve length calculations

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python --quiet` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_6896c6c86344832fadbf7f1f4a48e1da