### PR TITLE
Adjust chest measurement to use lower 30% of garment

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -73,8 +73,8 @@ def measure_clothes(image, cm_per_pixel):
     right_shoulder = (x + shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
     shoulder_width = right_shoulder[0] - left_shoulder[0]
 
-    # 身幅（胸あたり＝上から30%）
-    chest_y = y + int(h * 0.3)
+    # 身幅（下から30%）
+    chest_y = y + int(h * 0.7)
     chest_line = gray[chest_y:chest_y+5, x:x+w]
     chest_points = cv2.findNonZero(chest_line)
     if chest_points is None:


### PR DESCRIPTION
## Summary
- Measure chest width at 70% of garment height (bottom 30%) instead of top 30%
- Update related comment and ensure chest line uses new position

## Testing
- `python - <<'PY'
import importlib.machinery, importlib.util
loader = importlib.machinery.SourceFileLoader('Clothing', 'Clothing')
spec = importlib.util.spec_from_loader('Clothing', loader)
module = importlib.util.module_from_spec(spec)
try:
    loader.exec_module(module)
except Exception as e:
    print('Error:', e)
PY`
- `pip install opencv-python-headless pillow-heif rembg` *(fails: Tunnel connection failed: 403 Forbidden)*
- `pip install numpy` *(fails: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_6896c73520cc832f95264d48a1a99df4