### PR TITLE
Switch to PIL for Japanese text rendering

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -1,6 +1,6 @@
 import cv2
 import numpy as np
-from PIL import Image
+from PIL import Image, ImageDraw, ImageFont
 import pillow_heif
 import os
 from rembg import remove
@@ -134,15 +134,40 @@ def measure_clothes(image, cm_per_pixel):
     return hull, measures
 
 # 画像に寸法描画
-def draw_measurements_on_image(image, measurements):
-    font = cv2.FONT_HERSHEY_SIMPLEX
+def draw_measurements_on_image(image, measurements, font_path=None):
+    """Draw measurement text on an image using a font that supports Japanese.
+
+    Parameters
+    ----------
+    image : numpy.ndarray
+        BGR image as used by OpenCV.
+    measurements : dict
+        Dictionary mapping measurement names to values.
+    font_path : str, optional
+        Path to a TrueType font capable of rendering Japanese. If not
+        provided, the path is taken from the ``JP_FONT_PATH`` environment
+        variable. When no font can be loaded, Pillow's default font is used,
+        though it may not support Japanese characters.
+    """
+
+    if font_path is None:
+        font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc")
+
+    try:
+        font = ImageFont.truetype(font_path, size=32)
+    except OSError:
+        font = ImageFont.load_default()
+
+    pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
+    draw = ImageDraw.Draw(pil_img)
+
     y_offset = 30
     for key, value in measurements.items():
         text = f"{key}: {value:.1f} cm"
-        cv2.putText(image, text, (30, y_offset),
-                    font, 1, (0, 255, 0), 2, cv2.LINE_AA)
+        draw.text((30, y_offset), text, font=font, fill=(0, 255, 0))
         y_offset += 40
-    return image
+
+    return cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
 # ===== メイン処理 =====
 image_path = "画像.jpg"  # HEICもJPEGもOK
@@ -171,7 +196,8 @@ if contour is None:
 for k, v in measurements.items():
     print(f"{k}: {v:.1f} cm")
 
-img_with_text = draw_measurements_on_image(img.copy(), measurements)
+font_path = os.getenv("JP_FONT_PATH")
+img_with_text = draw_measurements_on_image(img.copy(), measurements, font_path=font_path)
 cv2.drawContours(img_with_text, [contour], -1, (255, 0, 0), 2)
 
 # 保存

--- a/README.md
+++ b/README.md
@@ -15,6 +15,15 @@
 - iPhoneなどのスマートフォン（将来的にはAndroidにも対応予定）
 - opencv-python, pillow-heif, rembg, numpy, Pillow
 
+### 日本語フォントについて
+寸法テキストを日本語で描画するためには日本語に対応したTrueTypeフォントが必要です。
+環境にフォントがインストールされていない場合は、以下のように環境変数 `JP_FONT_PATH`
+でフォントファイルのパスを指定してください。
+
+```bash
+export JP_FONT_PATH=/path/to/your/NotoSansJP-Regular.otf
+```
+
 ## インストール方法
 1. リポジトリをクローンします。
    ```bash

--- a/tests/test_draw_measurements_japanese.py
+++ b/tests/test_draw_measurements_japanese.py
@@ -1,0 +1,19 @@
+import os
+import importlib.util
+import numpy as np
+import cv2
+
+# Load Clothing module from script
+MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
+spec = importlib.util.spec_from_file_location('clothing', MODULE_PATH)
+clothing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clothing)
+
+
+def test_draw_measurements_with_japanese_font():
+    img = np.zeros((100, 200, 3), dtype=np.uint8)
+    measures = {"肩幅": 50.0}
+    font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+    out = clothing.draw_measurements_on_image(img.copy(), measures, font_path=font_path)
+    # Ensure drawing modified the image
+    assert np.any(out != img)


### PR DESCRIPTION
## Summary
- Render measurement labels with Pillow, allowing fonts that support Japanese characters
- Allow configurable font path via `JP_FONT_PATH` and document usage
- Add test verifying Japanese text drawing on output images

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install --no-input --quiet numpy pillow` *(fails: Could not connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_6896cb26ad2c832f8c95e48e21fce0b5