### PR TITLE
Guard main execution in Clothing module

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -169,38 +169,39 @@ def draw_measurements_on_image(image, measurements, font_path=None):
 
     return cv2.cvtColor(np.array(pil_img), cv2.COLOR_RGB2BGR)
 
-# ===== メイン処理 =====
-image_path = "画像.jpg"  # HEICもJPEGもOK
-img = load_image(image_path)
+if __name__ == "__main__":
+    # ===== メイン処理 =====
+    image_path = "画像.jpg"  # HEICもJPEGもOK
+    img = load_image(image_path)
 
-# マーカー検出（背景除去前）
-cm_per_pixel = detect_marker(img)
-if cm_per_pixel is None:
-    print("マーカーが検出できません。終了します。")
-    exit()
+    # マーカー検出（背景除去前）
+    cm_per_pixel = detect_marker(img)
+    if cm_per_pixel is None:
+        print("マーカーが検出できません。終了します。")
+        exit()
 
-# 背景除去
-img_no_bg = remove_background(img)
+    # 背景除去
+    img_no_bg = remove_background(img)
 
-# 服計測
-try:
-    contour, measurements = measure_clothes(img_no_bg, cm_per_pixel)
-except ValueError as e:
-    print(f"計測エラー: {e}")
-    exit()
-if contour is None:
-    print("服が検出できません。")
-    exit()
+    # 服計測
+    try:
+        contour, measurements = measure_clothes(img_no_bg, cm_per_pixel)
+    except ValueError as e:
+        print(f"計測エラー: {e}")
+        exit()
+    if contour is None:
+        print("服が検出できません。")
+        exit()
 
-# 寸法表示
-for k, v in measurements.items():
-    print(f"{k}: {v:.1f} cm")
+    # 寸法表示
+    for k, v in measurements.items():
+        print(f"{k}: {v:.1f} cm")
 
-font_path = os.getenv("JP_FONT_PATH")
-img_with_text = draw_measurements_on_image(img.copy(), measurements, font_path=font_path)
-cv2.drawContours(img_with_text, [contour], -1, (255, 0, 0), 2)
+    font_path = os.getenv("JP_FONT_PATH")
+    img_with_text = draw_measurements_on_image(img.copy(), measurements, font_path=font_path)
+    cv2.drawContours(img_with_text, [contour], -1, (255, 0, 0), 2)
 
-# 保存
-cv2.imwrite("clothes_with_measurements.jpg", img_with_text)
-print("寸法入り画像を保存しました → clothes_with_measurements.jpg")
+    # 保存
+    cv2.imwrite("clothes_with_measurements.jpg", img_with_text)
+    print("寸法入り画像を保存しました → clothes_with_measurements.jpg")
 


### PR DESCRIPTION
## Summary
- Prevent automatic execution of image loading and measurement logic by wrapping the main routine in an `if __name__ == '__main__'` block.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy — 403 ProxyError)*

------
https://chatgpt.com/codex/tasks/task_e_68981ca376e0832fa0e5a3023af7f20d