### PR TITLE
Add configurable font size for measurement labels

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -134,7 +134,7 @@ def measure_clothes(image, cm_per_pixel):
     return hull, measures
 
 # 画像に寸法描画
-def draw_measurements_on_image(image, measurements, font_path=None):
+def draw_measurements_on_image(image, measurements, font_path=None, font_size=150):
     """Draw measurement labels on an image using a Japanese-capable font.
 
     The overlay text defaults to a large 150 px font so measurements remain
@@ -153,13 +153,15 @@ def draw_measurements_on_image(image, measurements, font_path=None):
         provided, the path is taken from the ``JP_FONT_PATH`` environment
         variable. When no font can be loaded, Pillow's default font is used,
         though it may not support Japanese characters.
+    font_size : int, optional
+        Base font size to use for rendering measurement labels. Defaults to
+        150 px and is also used to derive line spacing.
     """
 
     if font_path is None:
         font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc")
 
     # Use a large font size so that text is clearly legible on high-resolution images
-    font_size = 150
     try:
 
         font = ImageFont.truetype(font_path, size=font_size)
@@ -212,7 +214,9 @@ if __name__ == "__main__":
         print(f"{k}: {v:.1f} cm")
 
     font_path = os.getenv("JP_FONT_PATH")
-    img_with_text = draw_measurements_on_image(img.copy(), measurements, font_path=font_path)
+    img_with_text = draw_measurements_on_image(
+        img.copy(), measurements, font_path=font_path, font_size=200
+    )
     cv2.drawContours(img_with_text, [contour], -1, (255, 0, 0), 2)
 
     # 保存

--- a/tests/test_draw_measurements_japanese.py
+++ b/tests/test_draw_measurements_japanese.py
@@ -14,6 +14,8 @@ def test_draw_measurements_with_japanese_font():
     img = np.zeros((100, 200, 3), dtype=np.uint8)
     measures = {"肩幅": 50.0}
     font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
-    out = clothing.draw_measurements_on_image(img.copy(), measures, font_path=font_path)
+    out = clothing.draw_measurements_on_image(
+        img.copy(), measures, font_path=font_path, font_size=20
+    )
     # Ensure drawing modified the image
     assert np.any(out != img)


### PR DESCRIPTION
## Summary
- allow `draw_measurements_on_image` to accept a `font_size` parameter
- derive line spacing from the provided font size and use it when rendering
- update script and tests to supply a font size when drawing measurements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_689827f29374832fbedf059669a58b38