### PR TITLE
Use pathlib for module path in Japanese font test

### DIFF
--- a/tests/test_draw_measurements_japanese.py
+++ b/tests/test_draw_measurements_japanese.py
@@ -1,10 +1,12 @@
 import os
 import importlib.util
+from pathlib import Path
 import numpy as np
 import cv2
 
 # Load Clothing module from script
-MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
+base = Path(__file__).resolve().parent if "__file__" in globals() else Path.cwd()
+MODULE_PATH = base / '..' / 'Clothing'
 spec = importlib.util.spec_from_file_location('clothing', MODULE_PATH)
 clothing = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(clothing)


### PR DESCRIPTION
## Summary
- Use `pathlib.Path` to construct module path in `test_draw_measurements_japanese.py`
- Derive base directory from `__file__` when available, falling back to `Path.cwd()`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python-headless` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68982d05cdb4832f843bcacb85a1b525