### PR TITLE
Improve Japanese font detection and document macOS font usage

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -133,6 +133,42 @@ def measure_clothes(image, cm_per_pixel):
     }
     return hull, measures
 
+def _load_japanese_font(font_path, font_size):
+    """Return a Pillow font object suitable for rendering Japanese text.
+
+    The function tries several fallback locations so that typical Linux and
+    macOS installations work out of the box:
+
+    1. The ``font_path`` argument, if provided.
+    2. The ``JP_FONT_PATH`` environment variable.
+    3. Common system fonts such as Noto Sans CJK (Linux) or Hiragino/Kosugi
+       (macOS).
+    4. Finally, Pillow's default bitmap font.
+    """
+
+    candidates = []
+    if font_path:
+        candidates.append(font_path)
+    else:
+        env_font = os.getenv("JP_FONT_PATH")
+        if env_font:
+            candidates.append(env_font)
+        candidates.extend([
+            "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc",  # Linux
+            "/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc",       # macOS
+            "/Library/Fonts/Kosugi-Regular.ttf",                       # macOS user font
+        ])
+
+    for path in candidates:
+        if path and os.path.exists(path):
+            try:
+                return ImageFont.truetype(path, size=font_size), font_size
+            except OSError:
+                continue
+
+    # Fall back to Pillow's default font which may not support Japanese
+    return ImageFont.load_default(), 20
+
 # 画像に寸法描画
 def draw_measurements_on_image(image, measurements, font_path=None, font_size=150):
     """Draw measurement labels on an image using a Japanese-capable font.
@@ -149,27 +185,22 @@ def draw_measurements_on_image(image, measurements, font_path=None, font_size=15
     measurements : dict
         Dictionary mapping measurement names to values.
     font_path : str, optional
-        Path to a TrueType font capable of rendering Japanese. If not
-        provided, the path is taken from the ``JP_FONT_PATH`` environment
-        variable. When no font can be loaded, Pillow's default font is used,
-        though it may not support Japanese characters.
+        Path to a TrueType font capable of rendering Japanese. When omitted,
+        the function searches in the following order:
+
+        1. The ``JP_FONT_PATH`` environment variable
+        2. Common system fonts (Noto Sans CJK on Linux, Hiragino/Kosugi on
+           macOS)
+        3. Pillow's bundled bitmap font, which may lack Japanese glyphs
     font_size : int, optional
         Base font size to use for rendering measurement labels. Defaults to
         150 px and is also used to derive line spacing.
     """
 
-    if font_path is None:
-        font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/noto/NotoSansCJK-Regular.ttc")
-
-    # Use a large font size so that text is clearly legible on high-resolution images
-    try:
-
-        font = ImageFont.truetype(font_path, size=font_size)
-
-    except OSError:
-        font = ImageFont.load_default()
-        # fall back to a conservative spacing when the default font is used
-        font_size = 20
+    # Resolve a Japanese-capable font. When no suitable font can be found,
+    # Pillow's default bitmap font is used and the size is reduced for better
+    # readability.
+    font, font_size = _load_japanese_font(font_path, font_size)
 
     pil_img = Image.fromarray(cv2.cvtColor(image, cv2.COLOR_BGR2RGB))
     draw = ImageDraw.Draw(pil_img)

--- a/README.md
+++ b/README.md
@@ -17,8 +17,10 @@
 
 ### 日本語フォントについて
 寸法テキストを日本語で描画するためには日本語に対応したTrueTypeフォントが必要です。
-環境にフォントがインストールされていない場合は、以下のように環境変数 `JP_FONT_PATH`
-でフォントファイルのパスを指定してください。
+環境にフォントがインストールされていない場合は、以下のように環境変数
+`JP_FONT_PATH` でフォントファイルのパスを指定してください。macOS の場合は
+`/System/Library/Fonts/ヒラギノ角ゴシック W3.ttc` や
+`/Library/Fonts/Kosugi-Regular.ttf` などを指定できます。
 
 ```bash
 export JP_FONT_PATH=/path/to/your/NotoSansJP-Regular.otf


### PR DESCRIPTION
## Summary
- handle Japanese font loading via `_load_japanese_font`, searching JP_FONT_PATH, Linux Noto and common macOS fonts before falling back to Pillow defaults
- update `draw_measurements_on_image` to use the helper and expand docstring
- clarify README about setting `JP_FONT_PATH` with examples for macOS font paths

## Testing
- `pytest` *(fails: No module named 'numpy')*
- `pip install numpy opencv-python pillow pillow-heif rembg` *(fails: Could not find a version that satisfies the requirement numpy; 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68982f2ff904832f8a65bb0a41853b70