### PR TITLE
Estimate body length using central line

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -65,23 +65,21 @@ def measure_clothes(image, cm_per_pixel):
     hull = cv2.convexHull(clothes_contour)
     x, y, w, h = cv2.boundingRect(hull)
 
-
-    # 最上点・最下点を取得
-    ys = clothes_contour[:, :, 1]
-    xs = clothes_contour[:, :, 0]
-    topmost = tuple(clothes_contour[ys.argmin()][0])
-    bottommost = tuple(clothes_contour[ys.argmax()][0])
-
-    min_x = int(xs.min())
-    max_x = int(xs.max())
-    min_y = int(ys.min())
-    max_y = int(ys.max())
-    w = max_x - min_x + 1
-    height = bottommost[1] - topmost[1]
+    # 二値マスクから胴体中央線を推定
+    mask = np.zeros_like(gray)
+    cv2.drawContours(mask, [clothes_contour], -1, 255, thickness=-1)
+    projection = mask.sum(axis=0)
+    center_x = int(np.argmax(projection))
+    column_pixels = np.where(mask[:, center_x] > 0)[0]
+    if column_pixels.size == 0:
+        raise ValueError("Center line not found")
+    top_y = int(column_pixels.min())
+    bottom_y = int(column_pixels.max())
+    height = bottom_y - top_y
 
     # 肩幅（上から10%の位置での幅）
-    shoulder_y = min_y + int(height * 0.1)
-    shoulder_line = gray[shoulder_y:shoulder_y+5, min_x:min_x+w]
+    shoulder_y = top_y + int(height * 0.1)
+    shoulder_line = mask[shoulder_y:shoulder_y + 5, x:x + w]
     shoulder_points = cv2.findNonZero(shoulder_line)
     if shoulder_points is None:
         raise ValueError("Shoulder line not detected")
@@ -89,21 +87,20 @@ def measure_clothes(image, cm_per_pixel):
     shoulder_ys = shoulder_points[:, 0, 1]
     left_idx = np.argmin(shoulder_xs)
     right_idx = np.argmax(shoulder_xs)
-    left_shoulder = (min_x + shoulder_xs[left_idx], shoulder_y + shoulder_ys[left_idx])
-    right_shoulder = (min_x + shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
+    left_shoulder = (x + shoulder_xs[left_idx], shoulder_y + shoulder_ys[left_idx])
+    right_shoulder = (x + shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
     shoulder_width = right_shoulder[0] - left_shoulder[0]
 
-
     # 身幅（下から30%）
-    chest_y = y + int(h * 0.7)
-    chest_line = gray[chest_y:chest_y+5, x:x+w]
+    chest_y = top_y + int(height * 0.7)
+    chest_line = mask[chest_y:chest_y + 5, x:x + w]
 
     chest_points = cv2.findNonZero(chest_line)
     if chest_points is None:
         raise ValueError("Chest line not detected")
     chest_xs = chest_points[:, 0, 0]
-    left_chest = min_x + chest_xs.min()
-    right_chest = min_x + chest_xs.max()
+    left_chest = x + chest_xs.min()
+    right_chest = x + chest_xs.max()
     chest_width = right_chest - left_chest
 
     # 袖端（凸包の左右端）
@@ -115,15 +112,10 @@ def measure_clothes(image, cm_per_pixel):
     right_sleeve_length = np.linalg.norm(np.array(right_shoulder) - np.array(right_sleeve_end))
     sleeve_length = (left_sleeve_length + right_sleeve_length) / 2
 
-
-    # 身丈（凸包の上下端）
-    top_point = hull[hull[:, :, 1].argmin()][0]
-    bottom_point = hull[hull[:, :, 1].argmax()][0]
-    body_length = bottom_point[1] - top_point[1]
-
-    # 身丈（最上点と最下点の距離）
-    body_length = bottommost[1] - topmost[1]
-
+    # 身丈（中央線と輪郭の交点間の距離）
+    top_point = np.array([center_x, top_y])
+    bottom_point = np.array([center_x, bottom_y])
+    body_length = float(np.linalg.norm(bottom_point - top_point))
 
     measures = {
         "肩幅": shoulder_width * cm_per_pixel,


### PR DESCRIPTION
## Summary
- project garment mask vertically to locate torso center and endpoints
- compute shoulder and chest widths using mask slices
- derive body length from central-axis intersection

## Testing
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy (ProxyError 403))*
- `pytest tests/test_measurements.py::test_measure_clothes_lengths -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b2469a30a0832fa2364491e54e9d41