### PR TITLE
test: add long sleeve measurement case

### DIFF
--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -22,6 +22,16 @@ def create_test_image():
     return img
 
 
+def create_long_sleeve_image():
+    img = np.zeros((300, 200, 3), dtype=np.uint8)
+    # body with extra length to ensure center column is tallest
+    cv2.rectangle(img, (80, 50), (120, 210), (255, 255, 255), -1)
+    # sleeves extending downward from under the shoulders
+    cv2.rectangle(img, (60, 110), (80, 240), (255, 255, 255), -1)
+    cv2.rectangle(img, (120, 110), (140, 240), (255, 255, 255), -1)
+    return img
+
+
 def test_measure_clothes_lengths():
     img = create_test_image()
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
@@ -30,4 +40,13 @@ def test_measure_clothes_lengths():
     assert abs(measures['身丈'] - 130) < 1.0
     # Expected sleeve length from shoulder (80,63) to sleeve end (30,90)
     expected_sleeve = np.hypot(80 - 30, 63 - 90)
+    assert abs(measures['袖丈'] - expected_sleeve) < 1.0
+
+
+def test_measure_clothes_long_sleeve_length():
+    img = create_long_sleeve_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    # Expected sleeve length from shoulder (80,66) to sleeve end (60,240)
+    expected_sleeve = np.hypot(80 - 60, 66 - 240)
     assert abs(measures['袖丈'] - expected_sleeve) < 1.0


### PR DESCRIPTION
## Summary
- add helper generating downward-sleeve dummy image
- cover long sleeve measurement in tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python pillow` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b25074cf8c832f86b40700383d8800