### PR TITLE
Compute sleeve length along skeleton path

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -2,6 +2,8 @@ import cv2
 import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 import os
+from heapq import heappush, heappop
+from skimage.morphology import skeletonize
 try:
     import pillow_heif
 except ImportError:  # pragma: no cover
@@ -56,6 +58,56 @@ def remove_background(image):
         raise ImportError("rembg is required for background removal")
     result = remove(image)
     return cv2.cvtColor(np.array(result), cv2.COLOR_RGBA2BGR)
+
+
+def _nearest_skeleton_point(skeleton, point):
+    """Return the skeleton pixel closest to ``point``.
+
+    Parameters
+    ----------
+    skeleton : ndarray
+        Binary skeleton image.
+    point : tuple
+        ``(x, y)`` coordinate.
+    """
+    ys, xs = np.nonzero(skeleton)
+    if xs.size == 0:
+        raise ValueError("Skeleton is empty")
+    dists = (xs - point[0]) ** 2 + (ys - point[1]) ** 2
+    idx = np.argmin(dists)
+    return int(xs[idx]), int(ys[idx])
+
+
+def _shortest_path_length(skeleton, start, end):
+    """Compute shortest path length between two points on a skeleton."""
+    height, width = skeleton.shape
+    visited = np.zeros((height, width), dtype=bool)
+    dist = np.full((height, width), np.inf)
+    sx, sy = start
+    ex, ey = end
+    dist[sy, sx] = 0.0
+    heap = [(0.0, sx, sy)]
+    neighbors = [
+        (-1, -1), (0, -1), (1, -1),
+        (-1, 0),           (1, 0),
+        (-1, 1),  (0, 1),  (1, 1),
+    ]
+    while heap:
+        d, x, y = heappop(heap)
+        if visited[y, x]:
+            continue
+        if (x, y) == (ex, ey):
+            return d
+        visited[y, x] = True
+        for dx, dy in neighbors:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height and skeleton[ny, nx]:
+                step = 1.41421356 if dx != 0 and dy != 0 else 1.0
+                nd = d + step
+                if nd < dist[ny, nx]:
+                    dist[ny, nx] = nd
+                    heappush(heap, (nd, nx, ny))
+    return np.inf
 
 # 服計測
 def measure_clothes(image, cm_per_pixel):
@@ -135,9 +187,15 @@ def measure_clothes(image, cm_per_pixel):
     left_sleeve_end = tuple(left_points[np.argmax(left_dists)])
     right_sleeve_end = tuple(right_points[np.argmax(right_dists)])
 
-    # 肩端から袖端までの距離
-    left_sleeve_length = left_dists.max()
-    right_sleeve_length = right_dists.max()
+    # 袖部分の骨格抽出
+    skeleton = skeletonize(mask > 0)
+    left_start = _nearest_skeleton_point(skeleton, left_shoulder)
+    left_end = _nearest_skeleton_point(skeleton, left_sleeve_end)
+    right_start = _nearest_skeleton_point(skeleton, right_shoulder)
+    right_end = _nearest_skeleton_point(skeleton, right_sleeve_end)
+
+    left_sleeve_length = _shortest_path_length(skeleton, left_start, left_end)
+    right_sleeve_length = _shortest_path_length(skeleton, right_start, right_end)
     sleeve_length = (left_sleeve_length + right_sleeve_length) / 2
 
 

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -11,10 +11,9 @@ spec.loader.exec_module(clothing)
 
 
 def create_test_image():
+    """Create a short-sleeve test image."""
     img = np.zeros((200, 200, 3), dtype=np.uint8)
-    # body
     cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
-    # sleeves (triangular) to give unique endpoints
     left_sleeve = np.array([[80, 70], [30, 90], [80, 110]], np.int32)
     right_sleeve = np.array([[120, 70], [170, 90], [120, 110]], np.int32)
     cv2.fillConvexPoly(img, left_sleeve, (255, 255, 255))
@@ -22,12 +21,28 @@ def create_test_image():
     return img
 
 
-def test_measure_clothes_lengths():
+def create_long_sleeve_image():
+    """Create a long-sleeve test image."""
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
+    # long, thin sleeves extending horizontally
+    cv2.rectangle(img, (20, 60), (80, 66), (255, 255, 255), -1)
+    cv2.rectangle(img, (120, 60), (180, 66), (255, 255, 255), -1)
+    return img
+
+
+def test_measure_clothes_lengths_short():
     img = create_test_image()
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
     assert contour is not None
-    # Expected body length between top y=50 and bottom y=180
     assert abs(measures['身丈'] - 130) < 1.0
-    # Expected sleeve length from shoulder (80,63) to sleeve end (30,90)
-    expected_sleeve = np.hypot(80 - 30, 63 - 90)
+    expected_sleeve = (90 - 63) + (80 - 30)  # vertical + horizontal along skeleton
+    assert abs(measures['袖丈'] - expected_sleeve) < 1.0
+
+
+def test_measure_clothes_lengths_long():
+    img = create_long_sleeve_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    expected_sleeve = 80 - 20  # horizontal length along skeleton
     assert abs(measures['袖丈'] - expected_sleeve) < 1.0


### PR DESCRIPTION
## Summary
- extract sleeve skeleton with `skimage.morphology.skeletonize`
- compute shortest path between shoulder and cuff on skeleton for sleeve length
- add tests comparing short- and long-sleeve measurements

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b25079afe4832f934cb3e0537d6221