### PR TITLE
Optimize sleeve search with single distance map

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -110,48 +110,64 @@ def _shortest_path_length(skeleton, start, end):
     return np.inf
 
 
-def _furthest_point(points, start):
-    """Return the furthest point from ``start`` along a skeleton.
+def _distance_map(skeleton, start):
+    """Return a distance map from ``start`` over the skeleton.
 
-    The function reconstructs a binary skeleton image from ``points`` and then
-    measures the shortest-path distance from ``start`` to every point using
-    :func:`_shortest_path_length`. The point with the greatest path length and
-    that distance are returned.
+    A Dijkstra search (equivalent to BFS with weighted diagonal steps) is
+    performed starting from ``start``. The resulting array holds the shortest
+    distance from ``start`` to every reachable skeleton pixel; non-skeleton
+    pixels remain at ``np.inf``.
+    """
+
+    height, width = skeleton.shape
+    dist = np.full((height, width), np.inf)
+    visited = np.zeros((height, width), dtype=bool)
+
+    sx, sy = _nearest_skeleton_point(skeleton, (int(start[0]), int(start[1])))
+    dist[sy, sx] = 0.0
+    heap = [(0.0, sx, sy)]
+
+    neighbors = [
+        (-1, -1), (0, -1), (1, -1),
+        (-1, 0),           (1, 0),
+        (-1, 1),  (0, 1),  (1, 1),
+    ]
+
+    while heap:
+        d, x, y = heappop(heap)
+        if visited[y, x]:
+            continue
+        visited[y, x] = True
+        for dx, dy in neighbors:
+            nx, ny = x + dx, y + dy
+            if 0 <= nx < width and 0 <= ny < height and skeleton[ny, nx]:
+                step = 1.41421356 if dx != 0 and dy != 0 else 1.0
+                nd = d + step
+                if nd < dist[ny, nx]:
+                    dist[ny, nx] = nd
+                    heappush(heap, (nd, nx, ny))
+    return dist
+
+
+def _furthest_point(points, dist):
+    """Return the point with maximum distance using a precomputed map.
 
     Parameters
     ----------
     points : ndarray
         ``(N, 2)`` array of ``(x, y)`` coordinates describing the skeleton.
-    start : array-like
-        Starting ``(x, y)`` coordinate.
-
-    Returns
-    -------
-    tuple
-        ``(furthest_point, distance)`` where ``furthest_point`` is the
-        ``(x, y)`` coordinate farthest from ``start`` and ``distance`` is the
-        shortest-path length to that point.
+    dist : ndarray
+        Distance map as returned by :func:`_distance_map`.
     """
 
     if points.size == 0:
-        start = (int(start[0]), int(start[1]))
-        return start, 0.0
+        return (0, 0), 0.0
 
-    max_x = int(max(points[:, 0].max(), start[0])) + 1
-    max_y = int(max(points[:, 1].max(), start[1])) + 1
-    skeleton = np.zeros((max_y, max_x), dtype=bool)
-    skeleton[points[:, 1], points[:, 0]] = True
-
-    sx, sy = _nearest_skeleton_point(skeleton, (int(start[0]), int(start[1])))
-
-    furthest = (sx, sy)
-    max_dist = 0.0
-    for x, y in points:
-        length = _shortest_path_length(skeleton, (sx, sy), (int(x), int(y)))
-        if length > max_dist:
-            max_dist = length
-            furthest = (int(x), int(y))
-    return furthest, float(max_dist)
+    dists = dist[points[:, 1], points[:, 0]]
+    idx = np.argmax(dists)
+    furthest = (int(points[idx, 0]), int(points[idx, 1]))
+    max_dist = float(dists[idx])
+    return furthest, max_dist
 
 # 服計測
 def measure_clothes(image, cm_per_pixel):
@@ -241,12 +257,12 @@ def measure_clothes(image, cm_per_pixel):
         skeleton, (center_x, top_y), (center_x, bottom_y)
     )
 
-    left_sleeve_end, left_sleeve_length = _furthest_point(
-        left_points, np.array(left_shoulder, dtype=np.float64)
-    )
-    right_sleeve_end, right_sleeve_length = _furthest_point(
-        right_points, np.array(right_shoulder, dtype=np.float64)
-    )
+    # Compute sleeve end points using distance maps from each shoulder.
+    left_dist = _distance_map(skeleton, np.array(left_shoulder, dtype=np.float64))
+    left_sleeve_end, left_sleeve_length = _furthest_point(left_points, left_dist)
+
+    right_dist = _distance_map(skeleton, np.array(right_shoulder, dtype=np.float64))
+    right_sleeve_end, right_sleeve_length = _furthest_point(right_points, right_dist)
 
     # 肩端から袖端までの距離（左右の平均）
     sleeve_length = (left_sleeve_length + right_sleeve_length) / 2


### PR DESCRIPTION
## Summary
- Replace per-point path search with a single Dijkstra-based distance map
- Reuse distance maps to find left and right sleeve ends without recomputing

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b2621dee4c832fb07bdfcc1358adbb