### PR TITLE
Optimize clothing measurement with ROI cropping and resizing

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -60,6 +60,39 @@ def remove_background(image):
     return cv2.cvtColor(np.array(result), cv2.COLOR_RGBA2BGR)
 
 
+def resize_for_speed(image, cm_per_pixel, max_size=1200):
+    """Downscale ``image`` so its longest side is ``max_size`` pixels.
+
+    Parameters
+    ----------
+    image : numpy.ndarray
+        Input BGR image.
+    cm_per_pixel : float
+        Conversion factor from pixels to centimeters at the current scale.
+    max_size : int, optional
+        Target size for the longest side. Images smaller than this are
+        returned unchanged. Defaults to ``1200``.
+
+    Returns
+    -------
+    tuple
+        ``(resized_image, adjusted_cm_per_pixel)`` where the scale factor is
+        applied equally to both dimensions and ``cm_per_pixel`` is divided by
+        that factor so real-world measurements remain accurate.
+    """
+
+    h, w = image.shape[:2]
+    long_side = max(h, w)
+    if long_side <= max_size:
+        return image, cm_per_pixel
+
+    scale = max_size / long_side
+    resized = cv2.resize(
+        image, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA
+    )
+    return resized, cm_per_pixel / scale
+
+
 def _nearest_skeleton_point(skeleton, point):
     """Return the skeleton pixel closest to ``point``.
 
@@ -160,7 +193,9 @@ def measure_clothes(image, cm_per_pixel):
     # ノイズ除去のためのクロージング処理
     kernel = np.ones((5, 5), np.uint8)
     thresh = cv2.morphologyEx(thresh, cv2.MORPH_CLOSE, kernel)
-    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+    contours, _ = cv2.findContours(
+        thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE
+    )
 
     if not contours:
         return None, {}
@@ -171,10 +206,13 @@ def measure_clothes(image, cm_per_pixel):
     hull = cv2.convexHull(clothes_contour)
     x, y, w, h = cv2.boundingRect(hull)
 
+    # ROIに切り出し後のマスクを作成
+    gray = gray[y:y + h, x:x + w]
+    mask = np.zeros((h, w), dtype=np.uint8)
+    shifted_contour = clothes_contour - [x, y]
+    cv2.drawContours(mask, [shifted_contour], -1, 255, thickness=-1)
 
     # 二値マスクから胴体中央線を推定
-    mask = np.zeros_like(gray)
-    cv2.drawContours(mask, [clothes_contour], -1, 255, thickness=-1)
     projection = mask.sum(axis=0)
     center_x = int(np.argmax(projection))
     column_pixels = np.where(mask[:, center_x] > 0)[0]
@@ -187,7 +225,7 @@ def measure_clothes(image, cm_per_pixel):
 
     # 肩幅（上から10%の位置での幅）
     shoulder_y = top_y + int(height * 0.1)
-    shoulder_line = mask[shoulder_y:shoulder_y + 5, x:x + w]
+    shoulder_line = mask[shoulder_y:shoulder_y + 5, :]
     shoulder_points = cv2.findNonZero(shoulder_line)
     if shoulder_points is None:
         raise ValueError("Shoulder line not detected")
@@ -195,8 +233,8 @@ def measure_clothes(image, cm_per_pixel):
     shoulder_ys = shoulder_points[:, 0, 1]
     left_idx = np.argmin(shoulder_xs)
     right_idx = np.argmax(shoulder_xs)
-    left_shoulder = (x + shoulder_xs[left_idx], shoulder_y + shoulder_ys[left_idx])
-    right_shoulder = (x + shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
+    left_shoulder = (shoulder_xs[left_idx], shoulder_y + shoulder_ys[left_idx])
+    right_shoulder = (shoulder_xs[right_idx], shoulder_y + shoulder_ys[right_idx])
     shoulder_width = right_shoulder[0] - left_shoulder[0]
 
 
@@ -208,13 +246,12 @@ def measure_clothes(image, cm_per_pixel):
     torso_mask = cv2.morphologyEx(torso_mask, cv2.MORPH_CLOSE, vertical_kernel)
 
     max_width = 0
-    left_chest = right_chest = None
-    center_rel = center_x - x
+    center_rel = center_x
     start_y = int(top_y + height * 0.25)
     end_y = int(top_y + height * 0.5)
 
     for y_pos in range(start_y, end_y):
-        row = torso_mask[y_pos, x:x + w]
+        row = torso_mask[y_pos]
         xs = np.where(row > 0)[0]
         if xs.size == 0:
             continue
@@ -224,13 +261,11 @@ def measure_clothes(image, cm_per_pixel):
                 width = seg[-1] - seg[0]
                 if width > max_width:
                     max_width = width
-                    left_chest = x + seg[0]
-                    right_chest = x + seg[-1]
                 break
 
     if max_width == 0:
         raise ValueError("Chest line not detected")
-    chest_width = right_chest - left_chest
+    chest_width = max_width
 
     skeleton = skeletonize(mask > 0)
     points = np.column_stack(np.nonzero(skeleton)[::-1])
@@ -352,6 +387,9 @@ if __name__ == "__main__":
     if cm_per_pixel is None:
         print("マーカーが検出できません。終了します。")
         exit()
+
+    # 必要に応じて画像を縮小し、縮尺も調整
+    img, cm_per_pixel = resize_for_speed(img, cm_per_pixel)
 
     # 背景除去
     img_no_bg = remove_background(img)

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -29,6 +29,7 @@ def create_long_sleeve_image():
     assert abs(measures['身丈'] - 130) < 1.0
     expected_sleeve = (90 - 63) + (80 - 30)  # vertical + horizontal along skeleton
     assert abs(measures['袖丈'] - expected_sleeve) < 1.0
+    return img
 
 
 def test_measure_clothes_lengths_long():

--- a/tests/test_resize_for_speed.py
+++ b/tests/test_resize_for_speed.py
@@ -1,0 +1,16 @@
+import os
+import importlib.util
+import numpy as np
+
+MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
+spec = importlib.util.spec_from_file_location('clothing', MODULE_PATH)
+clothing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clothing)
+
+
+def test_resize_for_speed_scales_and_adjusts():
+    img = np.zeros((2000, 1000, 3), dtype=np.uint8)
+    resized, cpp = clothing.resize_for_speed(img, cm_per_pixel=2.0, max_size=1200)
+    assert max(resized.shape[:2]) == 1200
+    expected_cpp = 2.0 / (1200 / 2000)
+    assert abs(cpp - expected_cpp) < 1e-6


### PR DESCRIPTION
## Summary
- Crop masks and all measurement operations to the garment's bounding box to reduce processing overhead
- Add `resize_for_speed` helper to downscale large images and update `cm_per_pixel` accordingly
- Provide unit test for resizing utility and fix test helper to return image

## Testing
- `pytest -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b2621f9e58832fbc0ce8554b0ecaf2