### PR TITLE
Optimize background removal with cached rembg session

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -9,9 +9,11 @@ try:
 except ImportError:  # pragma: no cover
     pillow_heif = None
 try:
-    from rembg import remove
+    import rembg
+    session = rembg.new_session("u2netp")
 except ImportError:  # pragma: no cover
-    remove = None
+    rembg = None
+    session = None
 
 # HEIC対応読み込み
 def load_image(path):
@@ -53,11 +55,41 @@ def detect_marker(image, marker_size_cm=5.0):
     return cm_per_pixel
 
 # 背景除去
-def remove_background(image):
-    if remove is None:
+def remove_background(image, max_size=None):
+    """Remove the background from ``image`` using a cached rembg session.
+
+    Parameters
+    ----------
+    image : ndarray
+        BGR image to process.
+    max_size : int, optional
+        If given, the image is scaled so that its longest side equals
+        ``max_size`` pixels before calling :func:`rembg.remove`. The result is
+        then resized back to the original resolution so subsequent measurement
+        code can operate on the original scale.
+    """
+
+    if rembg is None or session is None:
         raise ImportError("rembg is required for background removal")
-    result = remove(image)
-    return cv2.cvtColor(np.array(result), cv2.COLOR_RGBA2BGR)
+
+    orig_h, orig_w = image.shape[:2]
+
+    scale = 1.0
+    if max_size is not None:
+        longest = max(orig_h, orig_w)
+        if longest > max_size:
+            scale = max_size / float(longest)
+            new_w = int(orig_w * scale)
+            new_h = int(orig_h * scale)
+            image = cv2.resize(image, (new_w, new_h), interpolation=cv2.INTER_AREA)
+
+    result = rembg.remove(image, session=session)
+    result = cv2.cvtColor(np.array(result), cv2.COLOR_RGBA2BGR)
+
+    if scale != 1.0:
+        result = cv2.resize(result, (orig_w, orig_h), interpolation=cv2.INTER_LINEAR)
+
+    return result
 
 
 def _nearest_skeleton_point(skeleton, point):


### PR DESCRIPTION
## Summary
- Create a module-level rembg session using the lightweight `u2netp` model.
- Update `remove_background` to reuse this session and optionally downscale images before background removal.

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b262206600832fbfe4ddf22994b183