### PR TITLE
Prune skeleton branches before sleeve measurement

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -3,7 +3,12 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 import os
 from skimage.morphology import skeletonize
-from sleeve import _shortest_path_length, compute_sleeve_length
+from sleeve import (
+    _shortest_path_length,
+    compute_sleeve_length,
+    prune_skeleton,
+    DEFAULT_PRUNE_THRESHOLD,
+)
 try:
     import pillow_heif
 except ImportError:  # pragma: no cover
@@ -126,7 +131,7 @@ def resize_for_speed(image, cm_per_pixel, max_size=1200):
 
 
 # 服計測
-def measure_clothes(image, cm_per_pixel):
+def measure_clothes(image, cm_per_pixel, prune_threshold=DEFAULT_PRUNE_THRESHOLD):
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     _, thresh = cv2.threshold(gray, 10, 255, cv2.THRESH_BINARY)
     # ノイズ除去のためのクロージング処理
@@ -207,9 +212,14 @@ def measure_clothes(image, cm_per_pixel):
     chest_width = max_width
 
     skeleton = skeletonize(mask > 0)
+    skeleton = prune_skeleton(skeleton, prune_threshold)
     points = np.column_stack(np.nonzero(skeleton)[::-1])
     left_points = points[points[:, 0] < center_x]
     right_points = points[points[:, 0] >= center_x]
+
+    _, _, sleeve_length = compute_sleeve_length(
+        left_points, right_points, left_shoulder, right_shoulder
+    )
 
     body_length = _shortest_path_length(
         skeleton, (center_x, top_y), (center_x, bottom_y)

--- a/sleeve.py
+++ b/sleeve.py
@@ -8,7 +8,68 @@ from concurrent.futures import ThreadPoolExecutor
 from heapq import heappush, heappop
 from typing import Tuple
 
+import cv2
 import numpy as np
+
+# Default minimum branch length to keep when pruning skeletons. Exposed as a
+# module level constant so callers can tune it if needed.
+DEFAULT_PRUNE_THRESHOLD = 20
+
+
+def prune_skeleton(skeleton: np.ndarray, min_length: int = DEFAULT_PRUNE_THRESHOLD) -> np.ndarray:
+    """Remove short dangling branches from a skeleton image.
+
+    The function iteratively traces every end point in ``skeleton`` and removes
+    the branch if its length does not exceed ``min_length`` pixels. This helps
+    reduce spurious spurs introduced during skeletonisation so sleeve
+    measurements operate on a cleaner topology.
+    """
+
+    skel = skeleton.copy().astype(bool)
+    h, w = skel.shape
+    kernel = np.ones((3, 3), np.uint8)
+
+    def _trace_branch(x: int, y: int):
+        """Return coordinates along a branch starting from an endpoint."""
+
+        path = []
+        px, py = -1, -1
+        cx, cy = x, y
+        length = 0
+        while True:
+            path.append((cx, cy))
+            if length >= min_length:
+                break
+            neighbours = []
+            for dx in (-1, 0, 1):
+                for dy in (-1, 0, 1):
+                    if dx == 0 and dy == 0:
+                        continue
+                    nx, ny = cx + dx, cy + dy
+                    if 0 <= nx < w and 0 <= ny < h and skel[ny, nx]:
+                        if (nx, ny) != (px, py):
+                            neighbours.append((nx, ny))
+            if len(neighbours) != 1:
+                break
+            px, py = cx, cy
+            cx, cy = neighbours[0]
+            length += 1
+        return path
+
+    while True:
+        nb = cv2.filter2D(skel.astype(np.uint8), -1, kernel, borderType=cv2.BORDER_CONSTANT)
+        nb = nb - skel.astype(np.uint8)
+        ys, xs = np.where(skel & (nb == 1))
+        removed = False
+        for x, y in zip(xs, ys):
+            branch = _trace_branch(x, y)
+            if len(branch) - 1 <= min_length:
+                for bx, by in branch:
+                    skel[by, bx] = False
+                removed = True
+        if not removed:
+            break
+    return skel
 
 
 def _nearest_skeleton_point(skeleton: np.ndarray, point: Tuple[int, int]) -> Tuple[int, int]:
@@ -107,5 +168,7 @@ __all__ = [
     "_shortest_path_length",
     "_furthest_point",
     "compute_sleeve_length",
+    "prune_skeleton",
+    "DEFAULT_PRUNE_THRESHOLD",
 ]
 


### PR DESCRIPTION
## Summary
- prune short skeleton branches with configurable threshold
- use pruned skeleton for sleeve endpoint detection and length computation
- expose pruning threshold for future tuning

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b28cc41514832fb57635734b4f227e