### PR TITLE
Prune skeleton and split sleeve points

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -213,6 +213,12 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=DEFAULT_PRUNE_THRESHOLD
 
     skeleton = skeletonize(mask > 0)
 
+    skeleton = prune_skeleton(skeleton, prune_threshold)
+    ys, xs = np.nonzero(skeleton)
+    points = np.column_stack((xs, ys))
+    left_points = points[xs <= center_x]
+    right_points = points[xs >= center_x]
+
 
     _, _, sleeve_length = compute_sleeve_length(
         left_points, right_points, left_shoulder, right_shoulder


### PR DESCRIPTION
## Summary
- prune skeleton before measuring sleeves and split skeleton points into left/right sleeves

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b28f05aac4832fb7ce3a464d7c65eb