### PR TITLE
Improve marker detection robustness

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -33,10 +33,24 @@ def load_image(path):
         return cv2.imread(path)
 
 # 黒四角マーカー検出
-def detect_marker(image, marker_size_cm=5.0):
-    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
-    _, thresh = cv2.threshold(gray, 50, 255, cv2.THRESH_BINARY_INV)
-    contours, _ = cv2.findContours(thresh, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
+def detect_marker(image, marker_size_cm=5.0, debug=False):
+    """Detect a dark square marker and return its pixel-to-cm scale.
+
+    The original implementation relied on a fixed global threshold which is
+    prone to failure under uneven lighting.  We now isolate dark regions in
+    HSV colour space so shadows and highlights are handled more robustly.  The
+    function verifies that the candidate contour approximates a four sided
+    polygon and returns the corresponding centimetres-per-pixel value.  Unless
+    ``debug`` is ``True`` the input ``image`` is left unmodified.
+    """
+
+    # Use HSV thresholding to isolate dark regions regardless of illumination.
+    hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
+    lower = np.array([0, 0, 0])
+    upper = np.array([180, 255, 60])
+    mask = cv2.inRange(hsv, lower, upper)
+
+    contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
     cm_per_pixel = None
     best_cnt = None
@@ -44,19 +58,30 @@ def detect_marker(image, marker_size_cm=5.0):
 
     for cnt in contours:
         area = cv2.contourArea(cnt)
-        if area > 500:  # ノイズ除去
-            x, y, w, h = cv2.boundingRect(cnt)
-            aspect_ratio = w / float(h)
-            if 0.9 < aspect_ratio < 1.1 and area > max_area:
-                max_area = area
-                best_cnt = cnt
+        if area > 100:  # 小さいマーカーにも対応するため閾値を下げる
+            peri = cv2.arcLength(cnt, True)
+            approx = cv2.approxPolyDP(cnt, 0.02 * peri, True)
+            if len(approx) == 4:
+                x, y, w, h = cv2.boundingRect(approx)
+                aspect_ratio = w / float(h)
+                if 0.9 < aspect_ratio < 1.1 and area > max_area:
+                    max_area = area
+                    best_cnt = approx
 
     if best_cnt is not None:
         x, y, w, h = cv2.boundingRect(best_cnt)
         cm_per_pixel = marker_size_cm / np.mean([w, h])
-        cv2.rectangle(image, (x, y), (x + w, y + h), (0, 0, 255), 2)
-        cv2.putText(image, "Marker", (x, y - 10),
-                    cv2.FONT_HERSHEY_SIMPLEX, 0.6, (0, 0, 255), 2)
+        if debug:
+            cv2.rectangle(image, (x, y), (x + w, y + h), (0, 0, 255), 2)
+            cv2.putText(
+                image,
+                "Marker",
+                (x, y - 10),
+                cv2.FONT_HERSHEY_SIMPLEX,
+                0.6,
+                (0, 0, 255),
+                2,
+            )
     return cm_per_pixel
 
 # 背景除去


### PR DESCRIPTION
## Summary
- Switch marker detection to HSV-based thresholding for illumination robustness
- Validate contours via `cv2.approxPolyDP` with a lower area threshold
- Add optional debug overlay and avoid modifying input image by default

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b29048b288832f8c18cbc046ffb6a1