### PR TITLE
Derive prune threshold from garment height

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -7,7 +7,6 @@ from sleeve import (
     _shortest_path_length,
     compute_sleeve_length,
     prune_skeleton,
-    DEFAULT_PRUNE_THRESHOLD,
     _nearest_skeleton_point,
 )
 try:
@@ -207,7 +206,7 @@ def _split_sleeve_points(skeleton, left_shoulder, right_shoulder):
     left_points = np.column_stack((lx, ly))
     right_points = np.column_stack((rx, ry))
     return left_points, right_points
-def measure_clothes(image, cm_per_pixel, prune_threshold=DEFAULT_PRUNE_THRESHOLD):
+def measure_clothes(image, cm_per_pixel):
     gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
     _, thresh = cv2.threshold(gray, 10, 255, cv2.THRESH_BINARY)
     # ノイズ除去のためのクロージング処理
@@ -242,6 +241,7 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=DEFAULT_PRUNE_THRESHOLD
     bottom_y = int(column_pixels.max())
 
     height = bottom_y - top_y
+    prune_threshold = max(5, int(height * 0.02))
 
     # 肩幅（上から10%の位置での幅）
     shoulder_y = top_y + int(height * 0.1)

--- a/tests/test_very_short_sleeves.py
+++ b/tests/test_very_short_sleeves.py
@@ -1,0 +1,24 @@
+import os
+import importlib.util
+import numpy as np
+import cv2
+
+# Load Clothing module from the script without extension
+MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
+spec = importlib.util.spec_from_file_location('clothing', MODULE_PATH)
+clothing = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(clothing)
+
+def create_very_short_sleeve_image():
+    """Create a test image with extremely short sleeves."""
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
+    cv2.rectangle(img, (70, 60), (80, 70), (255, 255, 255), -1)
+    cv2.rectangle(img, (120, 60), (130, 70), (255, 255, 255), -1)
+    return img
+
+def test_measure_clothes_very_short_sleeve_length():
+    img = create_very_short_sleeve_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert abs(measures['袖丈'] - 10) < 1.0


### PR DESCRIPTION
## Summary
- compute prune threshold dynamically from clothing height before pruning skeleton
- add regression test for measuring very short sleeves accurately

## Testing
- `pytest -q` *(fails: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b2937b27d0832fa1f0cc3fd2c65394