### PR TITLE
Improve marker detection robustness

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -27,55 +27,85 @@ def load_image(path):
         return cv2.imread(path)
 
 # 黒四角マーカー検出
-def detect_marker(image, marker_size_cm=5.0, debug=False):
+def detect_marker(image, marker_size_cm: float = 5.0, debug: bool = False):
     """Detect a dark square marker and return its pixel-to-cm scale.
 
-    The original implementation relied on a fixed global threshold which is
-    prone to failure under uneven lighting.  We now isolate dark regions in
-    HSV colour space so shadows and highlights are handled more robustly.  The
-    function verifies that the candidate contour approximates a four sided
-    polygon and returns the corresponding centimetres-per-pixel value.  Unless
-    ``debug`` is ``True`` the input ``image`` is left unmodified.
+    The previous implementation relied on simple HSV thresholding with a fixed
+    value.  This was brittle in real photographs where lighting conditions
+    change across the frame or the image contains small noise speckles.  The
+    current approach performs the following steps:
+
+    1. Convert to grey and apply both Otsu and adaptive thresholding so the
+       binary mask adapts to global as well as local illumination.
+    2. Use ``cv2.morphologyEx`` with opening and closing operations to remove
+       small artefacts from the mask.
+    3. Extract contours and evaluate each using ``cv2.minAreaRect`` so rotated
+       markers are handled correctly.  Candidates are filtered by aspect ratio
+       and area to avoid false positives.
     """
 
-    # Use HSV thresholding to isolate dark regions regardless of illumination.
-    hsv = cv2.cvtColor(image, cv2.COLOR_BGR2HSV)
-    lower = np.array([0, 0, 0])
-    upper = np.array([180, 255, 60])
-    mask = cv2.inRange(hsv, lower, upper)
+    # --- Step 1: robust binarisation ------------------------------------
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    blur = cv2.GaussianBlur(gray, (5, 5), 0)
 
+    # Global Otsu thresholding combined with adaptive thresholding for local
+    # variations.  The union of both masks works well for diverse lighting.
+    _, otsu = cv2.threshold(
+        blur, 0, 255, cv2.THRESH_BINARY_INV + cv2.THRESH_OTSU
+    )
+    adaptive = cv2.adaptiveThreshold(
+        blur, 255, cv2.ADAPTIVE_THRESH_GAUSSIAN_C, cv2.THRESH_BINARY_INV, 51, 5
+    )
+    mask = cv2.bitwise_or(otsu, adaptive)
+
+    # --- Step 2: morphological noise removal ----------------------------
+    kernel = np.ones((3, 3), np.uint8)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_OPEN, kernel, iterations=1)
+    mask = cv2.morphologyEx(mask, cv2.MORPH_CLOSE, kernel, iterations=1)
+
+    # --- Step 3: contour analysis ---------------------------------------
     contours, _ = cv2.findContours(mask, cv2.RETR_EXTERNAL, cv2.CHAIN_APPROX_SIMPLE)
 
     cm_per_pixel = None
-    best_cnt = None
-    max_area = 0
+    best_rect = None
+    max_area = 0.0
 
     for cnt in contours:
         area = cv2.contourArea(cnt)
-        if area > 100:  # 小さいマーカーにも対応するため閾値を下げる
-            peri = cv2.arcLength(cnt, True)
-            approx = cv2.approxPolyDP(cnt, 0.02 * peri, True)
-            if len(approx) == 4:
-                x, y, w, h = cv2.boundingRect(approx)
-                aspect_ratio = w / float(h)
-                if 0.9 < aspect_ratio < 1.1 and area > max_area:
-                    max_area = area
-                    best_cnt = approx
+        if area < 100:  # ignore tiny blobs
+            continue
 
-    if best_cnt is not None:
-        x, y, w, h = cv2.boundingRect(best_cnt)
+        rect = cv2.minAreaRect(cnt)
+        (cx, cy), (w, h), angle = rect
+        if w == 0 or h == 0:
+            continue
+
+        aspect_ratio = w / h if w > h else h / w
+        rect_area = w * h
+
+        # Accept nearly square shapes with sufficient area
+        if 0.8 < aspect_ratio < 1.25 and rect_area > max_area:
+            max_area = rect_area
+            best_rect = rect
+
+    if best_rect is not None:
+        (cx, cy), (w, h), angle = best_rect
         cm_per_pixel = marker_size_cm / np.mean([w, h])
+
         if debug:
-            cv2.rectangle(image, (x, y), (x + w, y + h), (0, 0, 255), 2)
+            box = cv2.boxPoints(best_rect)
+            box = np.intp(box)
+            cv2.drawContours(image, [box], 0, (0, 0, 255), 2)
             cv2.putText(
                 image,
                 "Marker",
-                (x, y - 10),
+                (int(cx), int(cy)),
                 cv2.FONT_HERSHEY_SIMPLEX,
                 0.6,
                 (0, 0, 255),
                 2,
             )
+
     return cm_per_pixel
 
 # 背景除去

--- a/tests/test_detect_marker.py
+++ b/tests/test_detect_marker.py
@@ -1,0 +1,56 @@
+import importlib.util
+from pathlib import Path
+
+import cv2
+import numpy as np
+import pytest
+
+
+def _load_module():
+    """Load the ``Clothing`` module regardless of its file name.
+
+    The repository stores the main implementation in a file named ``Clothing``
+    without the usual ``.py`` extension.  ``importlib`` is therefore used to
+    load it in the tests.
+    """
+
+    module_path = Path(__file__).resolve().parent.parent / "Clothing"
+    spec = importlib.util.spec_from_file_location("clothing", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.mark.parametrize("bg_color, angle", [(255, 0), (120, 0), (255, 45), (120, 30)])
+def test_detect_marker_various_conditions(bg_color, angle):
+    clothing = _load_module()
+
+    # Create a background with a mild gradient to emulate uneven lighting
+    grad = np.tile(
+        np.linspace(max(0, bg_color - 20), min(255, bg_color + 20), 200, dtype=np.uint8),
+        (200, 1),
+    )
+    img = cv2.merge([grad, grad, grad])
+
+    # Insert a black square marker at the centre
+    cv2.rectangle(img, (75, 75), (125, 125), (0, 0, 0), -1)
+
+    # Add random noise so morphological opening/closing are exercised
+    rng = np.random.default_rng(0)
+    coords = rng.integers(0, 200, (300, 2))
+    for x, y in coords:
+        img[y, x] = (255, 255, 255) if rng.random() > 0.5 else (0, 0, 0)
+
+    # Rotate the image if required to check handling of rotated markers
+    if angle:
+        M = cv2.getRotationMatrix2D((100, 100), angle, 1.0)
+        img = cv2.warpAffine(
+            img, M, (200, 200), flags=cv2.INTER_LINEAR, borderValue=(bg_color, bg_color, bg_color)
+        )
+
+    cm_per_pixel = clothing.detect_marker(img.copy(), marker_size_cm=5.0)
+
+    assert cm_per_pixel is not None
+    # The marker is 50x50 pixels → 5cm / 50px = 0.1 cm per pixel.
+    assert abs(cm_per_pixel - 0.1) < 0.02
+


### PR DESCRIPTION
## Summary
- enhance `Clothing.detect_marker` with Otsu + adaptive thresholding, morphological noise filtering and rotated marker support via `cv2.minAreaRect`
- add tests exercising marker detection under varied lighting, noise and rotation conditions

## Testing
- `pytest tests/test_detect_marker.py -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68b39bfdddc4832fb1e8393bd222a789