### PR TITLE
Add configurable pruning and sleeve separation test

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -138,6 +138,17 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=DEFAULT_PRUNE_THRESHOLD
         raise ValueError("Chest line not detected")
     chest_width = max_width
 
+    # Erode horizontally around the armpit region to weaken the connection
+    # between sleeves and torso before skeletonisation. This helps ensure the
+    # sleeves are treated as separate branches when extracting their skeletons.
+    armpit_start = top_y + int(height * 0.2)
+    armpit_end = top_y + int(height * 0.4)
+    kernel_width = max(3, w // 30)
+    horiz_kernel = np.ones((1, kernel_width), np.uint8)
+    mask[armpit_start:armpit_end] = cv2.erode(
+        mask[armpit_start:armpit_end], horiz_kernel
+    )
+
     skeleton = skeletonize(mask > 0)
 
     skeleton = prune_skeleton(skeleton, prune_threshold)

--- a/sleeve.py
+++ b/sleeve.py
@@ -7,13 +7,16 @@ parallelised or even executed on separate workers in the future.
 from concurrent.futures import ThreadPoolExecutor
 from heapq import heappush, heappop
 from typing import Tuple
+import os
 
 import cv2
 import numpy as np
 
 # Default minimum branch length to keep when pruning skeletons. Exposed as a
-# module level constant so callers can tune it if needed.
-DEFAULT_PRUNE_THRESHOLD = 20
+# module level constant so callers can tune it if needed. The value can also be
+# overridden via the ``PRUNE_THRESHOLD`` environment variable to better suit
+# different sleeve lengths.
+DEFAULT_PRUNE_THRESHOLD = int(os.getenv("PRUNE_THRESHOLD", "20"))
 
 
 def prune_skeleton(skeleton: np.ndarray, min_length: int = DEFAULT_PRUNE_THRESHOLD) -> np.ndarray:

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -3,6 +3,7 @@ import importlib.util
 import numpy as np
 import cv2
 from sleeve import compute_sleeve_length
+from measurements import _split_sleeve_points
 
 # Load Clothing module from the script without extension
 MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
@@ -63,3 +64,17 @@ def test_compute_sleeve_length_disconnected_branch():
     assert np.isfinite(sleeve_length)
     assert right_end == right_shoulder
     assert np.isclose(sleeve_length, 2.0)
+
+
+def test_split_sleeve_points_separates_sleeves():
+    skeleton = np.zeros((40, 80), dtype=bool)
+    skeleton[5:35, 40] = True  # body
+    skeleton[15, 10:40] = True  # left sleeve
+    skeleton[15, 40:70] = True  # right sleeve
+    left_shoulder = (10, 15)
+    right_shoulder = (70, 15)
+    left_points, right_points = _split_sleeve_points(
+        skeleton, left_shoulder, right_shoulder
+    )
+    assert left_points.size > 0 and right_points.size > 0
+    assert left_points[:, 0].max() < right_points[:, 0].min()


### PR DESCRIPTION
## Summary
- Erode mask around armpits before skeletonization to weaken sleeve-torso connection
- Allow pruning threshold to be set via `PRUNE_THRESHOLD` env var
- Add unit test verifying sleeve branch separation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install -q numpy opencv-python-headless scikit-image` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68b3f82208e8832f82356504a3eb531c