### PR TITLE
Import shortest path helper from sleeve

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -59,7 +59,7 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
     # Import lazily to avoid circular imports when :mod:`sleeve` needs
     # ``measure_clothes`` from this module.
     from sleeve import (
-
+        _shortest_path_length,
         compute_sleeve_length,
         prune_skeleton,
         DEFAULT_PRUNE_THRESHOLD,
@@ -194,5 +194,5 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
     return hull, measures
 
 
-__all__ = ["measure_clothes", "_split_sleeve_points", "_shortest_path_length"]
+__all__ = ["measure_clothes", "_split_sleeve_points"]
 


### PR DESCRIPTION
## Summary
- ensure `_shortest_path_length` is imported from `sleeve` within `measure_clothes`
- clean up `__all__` in `measurements.py`

## Testing
- `python -m py_compile measurements.py sleeve.py`
- `pytest -q` *(fails: No module named 'cv2'; No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68b3ff796988832f9fc7d80d6a171a49