### PR TITLE
Handle missing shortest path helper

### DIFF
--- a/sleeve.py
+++ b/sleeve.py
@@ -136,6 +136,13 @@ def _shortest_path_length(
     return float(np.inf)
 
 
+# Backwards compatible public alias.  Some callers historically imported the
+# private ``_shortest_path_length`` symbol directly; others expect a public
+# ``shortest_path_length``.  Export both names so either style continues to
+# work without raising ``ImportError``.
+shortest_path_length = _shortest_path_length
+
+
 def _furthest_point(points: np.ndarray, start: np.ndarray):
     """Return the furthest point from ``start`` along a skeleton."""
 
@@ -193,6 +200,7 @@ __all__ = [
     "_nearest_skeleton_point",
     "_skeleton_endpoints",
     "_shortest_path_length",
+    "shortest_path_length",
     "_furthest_point",
     "compute_sleeve_length",
     "prune_skeleton",


### PR DESCRIPTION
## Summary
- ensure garment measurement works even with older sleeve modules by falling back to a local shortest path implementation
- expose `shortest_path_length` as public alias in `sleeve` to prevent import errors

## Testing
- `pytest tests/test_measurements.py::test_compute_sleeve_length_disconnected_branch -q` *(fails: ModuleNotFoundError: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68b402560100832fa6ae99ce29d0288f