### PR TITLE
Ignore large dark regions when detecting marker

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -100,6 +100,7 @@ def detect_marker(image, marker_size_cm: float = 5.0, debug: bool = False):
     cm_per_pixel = None
     best_rect = None
     max_area = 0.0
+    image_area = image.shape[0] * image.shape[1]
 
     for cnt in contours:
         area = cv2.contourArea(cnt)
@@ -113,6 +114,13 @@ def detect_marker(image, marker_size_cm: float = 5.0, debug: bool = False):
 
         aspect_ratio = w / h if w > h else h / w
         rect_area = w * h
+
+        # Ignore very large candidates that likely correspond to garment parts
+        # (e.g. short sleeves) rather than the small calibration marker.  The
+        # marker is expected to be only a tiny fraction of the image so we
+        # discard anything covering more than roughly a quarter of the frame.
+        if rect_area > image_area * 0.25:
+            continue
 
         if 0.8 < aspect_ratio < 1.25:
             box = cv2.boxPoints(rect)

--- a/tests/test_detect_marker.py
+++ b/tests/test_detect_marker.py
@@ -104,3 +104,22 @@ def test_detect_marker_perspective_and_partial(mode):
     assert cm_per_pixel is not None
     assert abs(cm_per_pixel - expected_cpp) < 0.03
 
+
+def test_detect_marker_ignores_large_dark_regions():
+    """Large dark areas resembling sleeves should not be misidentified as markers."""
+    clothing = _load_module()
+
+    img = np.full((200, 200, 3), 255, dtype=np.uint8)
+
+    # Simulate a large dark sleeve occupying much of the frame
+    cv2.rectangle(img, (0, 0), (150, 150), (0, 0, 0), -1)
+
+    # Place the actual 40x40 marker in the opposite corner
+    cv2.rectangle(img, (150, 150), (190, 190), (0, 0, 0), -1)
+
+    cm_per_pixel = clothing.detect_marker(img.copy(), marker_size_cm=5.0)
+
+    # 5 cm marker represented by 40 pixels → 0.125 cm per pixel expected
+    assert cm_per_pixel is not None
+    assert abs(cm_per_pixel - 0.125) < 0.02
+


### PR DESCRIPTION
## Summary
- avoid misidentifying sleeves as calibration marker by skipping contour candidates occupying over 25% of the image
- add regression test ensuring large dark regions are ignored during marker detection

## Testing
- `pytest tests/test_detect_marker.py::test_detect_marker_ignores_large_dark_regions -q` *(fails: No module named 'cv2')*


------
https://chatgpt.com/codex/tasks/task_e_68b4103a2c38832f8596046e0ed3ec56