### PR TITLE
Add short-sleeve detection based on sleeve-to-body ratio

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -3,6 +3,9 @@ import numpy as np
 from skimage.morphology import skeletonize
 
 
+SHORT_SLEEVE_RATIO_THRESHOLD = 0.35
+
+
 def _split_sleeve_points(skeleton, left_shoulder, right_shoulder):
     """Split ``skeleton`` into left/right sleeve points via flood fill."""
     from collections import deque
@@ -223,12 +226,18 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
         skeleton, (center_x, top_y), (center_x, bottom_y)
     )
 
+    sleeve_ratio = sleeve_length / body_length if body_length else 0
+
     measures = {
         "肩幅": shoulder_width * cm_per_pixel,
         "身幅": chest_width * cm_per_pixel,
         "身丈": body_length * cm_per_pixel,
-        "袖丈": sleeve_length * cm_per_pixel,
     }
+    if sleeve_ratio >= SHORT_SLEEVE_RATIO_THRESHOLD:
+        measures["袖丈"] = sleeve_length * cm_per_pixel
+    else:
+        measures["袖タイプ"] = "短袖"
+
     return hull, measures
 
 

--- a/tests/test_measurements_short_sleeve_ratio.py
+++ b/tests/test_measurements_short_sleeve_ratio.py
@@ -1,0 +1,38 @@
+import numpy as np
+import cv2
+
+from measurements import measure_clothes
+
+
+def create_short_sleeve_image():
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
+    left_sleeve = np.array([[80, 70], [30, 90], [80, 110]], np.int32)
+    right_sleeve = np.array([[120, 70], [170, 90], [120, 110]], np.int32)
+    cv2.fillConvexPoly(img, left_sleeve, (255, 255, 255))
+    cv2.fillConvexPoly(img, right_sleeve, (255, 255, 255))
+    return img
+
+
+def create_long_sleeve_image():
+    img = np.zeros((200, 300, 3), dtype=np.uint8)
+    cv2.rectangle(img, (100, 50), (200, 180), (255, 255, 255), -1)
+    cv2.rectangle(img, (50, 70), (100, 150), (255, 255, 255), -1)
+    cv2.rectangle(img, (200, 70), (250, 150), (255, 255, 255), -1)
+    return img
+
+
+def test_short_sleeve_excluded_sleeve_length():
+    img = create_short_sleeve_image()
+    contour, measures = measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert "袖丈" not in measures
+    assert measures.get("袖タイプ") == "短袖"
+
+
+def test_long_sleeve_keeps_sleeve_length():
+    img = create_long_sleeve_image()
+    contour, measures = measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert "袖丈" in measures
+    assert "袖タイプ" not in measures


### PR DESCRIPTION
## Summary
- add `SHORT_SLEEVE_RATIO_THRESHOLD` constant and sleeve-to-body ratio check
- omit sleeve measurement and mark garment as short-sleeved when ratio is below threshold
- add tests covering short vs long sleeve scenarios

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python-headless scikit-image pillow -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68be71de7508832f84dda9a4a0ecd7cf