### PR TITLE
Handle disconnected skeleton in body length

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -59,7 +59,12 @@ def _split_sleeve_points(skeleton, left_shoulder, right_shoulder):
 
 
 def measure_clothes(image, cm_per_pixel, prune_threshold=None):
-    """Measure key dimensions of the garment contained in ``image``."""
+    """Measure key dimensions of the garment contained in ``image``.
+
+    When the skeleton representing the garment's centre line is disconnected
+    and no path can be found between top and bottom, the body length falls back
+    to the bounding-box height instead of returning infinity.
+    """
 
     # Import lazily to avoid circular imports when :mod:`sleeve` needs
     # ``measure_clothes`` from this module.  Older installations of
@@ -225,6 +230,10 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
     body_length = _shortest_path_length(
         skeleton, (center_x, top_y), (center_x, bottom_y)
     )
+    if np.isinf(body_length):
+        # Center line is disconnected; fall back to a simple top-to-bottom
+        # measurement derived from the bounding box height.
+        body_length = bottom_y - top_y
 
     sleeve_ratio = sleeve_length / body_length if body_length else 0
 

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -76,3 +76,20 @@ def test_compute_sleeve_length_disconnected_branch():
 
 
 
+def test_measure_clothes_disconnected_skeleton_fallback(monkeypatch):
+    img = create_test_image()
+
+    # Simulate a disconnected skeleton by forcing the shortest path to return
+    # infinity. The measurement should fall back to the bounding-box height
+    # instead of propagating ``inf``.
+    monkeypatch.setattr(
+        "sleeve._shortest_path_length", lambda *args, **kwargs: float("inf")
+    )
+
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert np.isfinite(measures["身丈"])
+    # The bounding-box height of ``create_test_image`` is 130 pixels.
+    assert abs(measures["身丈"] - 130) < 1.0
+
+


### PR DESCRIPTION
## Summary
- document and handle disconnected body skeletons by falling back to bounding-box height
- add regression test ensuring disconnected skeletons no longer yield infinite body length

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install numpy opencv-python-headless -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68be75f53510832fbbd131a08a2c20e5