### PR TITLE
Always include sleeve length measurement

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -3,9 +3,6 @@ import numpy as np
 from skimage.morphology import skeletonize
 
 
-SHORT_SLEEVE_RATIO_THRESHOLD = 0.35
-
-
 def _split_sleeve_points(skeleton, left_shoulder, right_shoulder):
     """Split ``skeleton`` into left/right sleeve points via flood fill."""
     from collections import deque
@@ -235,17 +232,12 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
         # measurement derived from the bounding box height.
         body_length = bottom_y - top_y
 
-    sleeve_ratio = sleeve_length / body_length if body_length else 0
-
     measures = {
         "肩幅": shoulder_width * cm_per_pixel,
         "身幅": chest_width * cm_per_pixel,
         "身丈": body_length * cm_per_pixel,
+        "袖丈": sleeve_length * cm_per_pixel,
     }
-    if sleeve_ratio >= SHORT_SLEEVE_RATIO_THRESHOLD:
-        measures["袖丈"] = sleeve_length * cm_per_pixel
-    else:
-        measures["袖タイプ"] = "短袖"
 
     return hull, measures
 

--- a/tests/test_draw_measurements_japanese.py
+++ b/tests/test_draw_measurements_japanese.py
@@ -15,8 +15,10 @@ spec.loader.exec_module(clothing)
 
 def test_draw_and_print_measurements_with_japanese_font_and_string(capfd):
     img = np.zeros((100, 200, 3), dtype=np.uint8)
-    measures = {"肩幅": 50.0, "袖タイプ": "長袖"}
-    font_path = os.getenv("JP_FONT_PATH", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf")
+    measures = {"肩幅": 50.0, "袖丈": 60.0, "備考": "テスト"}
+    font_path = os.getenv(
+        "JP_FONT_PATH", "/usr/share/fonts/truetype/dejavu/DejaVuSans.ttf"
+    )
     out = clothing.draw_measurements_on_image(
         img.copy(), measures, font_path=font_path
     )
@@ -31,4 +33,5 @@ def test_draw_and_print_measurements_with_japanese_font_and_string(capfd):
             print(f"{k}: {v}")
     captured = capfd.readouterr()
     assert "肩幅: 50.0 cm" in captured.out
-    assert "袖タイプ: 長袖" in captured.out
+    assert "袖丈: 60.0 cm" in captured.out
+    assert "備考: テスト" in captured.out

--- a/tests/test_measurements_short_sleeve_ratio.py
+++ b/tests/test_measurements_short_sleeve_ratio.py
@@ -22,12 +22,12 @@ def create_long_sleeve_image():
     return img
 
 
-def test_short_sleeve_excluded_sleeve_length():
+def test_short_sleeve_returns_sleeve_length():
     img = create_short_sleeve_image()
     contour, measures = measure_clothes(img, cm_per_pixel=1.0)
     assert contour is not None
-    assert "袖丈" not in measures
-    assert measures.get("袖タイプ") == "短袖"
+    assert "袖丈" in measures
+    assert "袖タイプ" not in measures
 
 
 def test_long_sleeve_keeps_sleeve_length():


### PR DESCRIPTION
## Summary
- Remove short-sleeve classification and always return a numeric sleeve length
- Update Japanese font test and sleeve tests to reflect new measurement output

## Testing
- ⚠️ `pip install -q numpy opencv-python-headless` (failed: proxy 403)
- ⚠️ `pytest -q` (missing cv2 and numpy modules)

------
https://chatgpt.com/codex/tasks/task_e_68be775793dc832f829a51dcbcdbe665