### PR TITLE
Improve center line detection for chest width

### DIFF
--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -43,6 +43,15 @@ def create_long_sleeve_width_image():
     return img
 
 
+def create_very_long_sleeve_image():
+    """Create an image where sleeves extend far beyond the torso."""
+    img = np.zeros((300, 300, 3), dtype=np.uint8)
+    cv2.rectangle(img, (100, 100), (200, 230), (255, 255, 255), -1)
+    cv2.rectangle(img, (50, 50), (100, 280), (255, 255, 255), -1)
+    cv2.rectangle(img, (200, 50), (250, 280), (255, 255, 255), -1)
+    return img
+
+
 def test_measure_clothes_lengths_long():
     img = create_long_sleeve_image()
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
@@ -91,5 +100,12 @@ def test_measure_clothes_disconnected_skeleton_fallback(monkeypatch):
     assert np.isfinite(measures["身丈"])
     # The bounding-box height of ``create_test_image`` is 130 pixels.
     assert abs(measures["身丈"] - 130) < 1.0
+
+
+def test_measure_clothes_chest_width_with_long_sleeves():
+    img = create_very_long_sleeve_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert abs(measures["身幅"] - 100) < 1.0
 
 


### PR DESCRIPTION
## Summary
- Derive garment center line from centroid and search neighboring columns when empty to stabilise chest width measurement
- Add regression test to ensure chest width is computed correctly even when sleeves dominate the image

## Testing
- `pytest -q` *(fails: No module named 'cv2', 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_68be877eedac832f9487e9d795c25204