### PR TITLE
Use median chest width to avoid protrusion outliers

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -208,7 +208,7 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
         torso_only[labels == lbl] = 255
     torso_mask = torso_only
 
-    max_width = 0
+    widths = []
     start_y = int(top_y + height * 0.25)
     end_y = int(top_y + height * 0.5)
 
@@ -220,14 +220,12 @@ def measure_clothes(image, cm_per_pixel, prune_threshold=None):
         segments = np.split(xs, np.where(np.diff(xs) > 1)[0] + 1)
         for seg in segments:
             if seg[0] <= center_rel <= seg[-1]:
-                width = seg[-1] - seg[0]
-                if width > max_width:
-                    max_width = width
+                widths.append(seg[-1] - seg[0])
                 break
 
-    if max_width == 0:
+    if not widths:
         raise ValueError("Chest line not detected")
-    chest_width = max_width
+    chest_width = float(np.median(widths))
 
     # Erode horizontally around the armpit region to weaken the connection
     # between sleeves and torso before skeletonisation. This helps ensure the

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -52,6 +52,16 @@ def create_very_long_sleeve_image():
     return img
 
 
+def create_chest_width_outlier_image():
+    """Create an image with a small protrusion around the chest area."""
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    cv2.rectangle(img, (80, 50), (120, 180), (255, 255, 255), -1)
+    # Add a narrow triangle on the left side that should be ignored
+    protrusion = np.array([[80, 100], [30, 110], [80, 120]], np.int32)
+    cv2.fillConvexPoly(img, protrusion, (255, 255, 255))
+    return img
+
+
 def test_measure_clothes_lengths_long():
     img = create_long_sleeve_image()
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
@@ -107,5 +117,12 @@ def test_measure_clothes_chest_width_with_long_sleeves():
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
     assert contour is not None
     assert abs(measures["身幅"] - 100) < 1.0
+
+
+def test_measure_clothes_chest_width_ignores_outlier():
+    img = create_chest_width_outlier_image()
+    contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
+    assert contour is not None
+    assert abs(measures["身幅"] - 40) < 1.0
 
 


### PR DESCRIPTION
## Summary
- make chest width measurement robust to small protrusions by using the median of sampled rows
- add regression test ensuring width ignores narrow outliers

## Testing
- `pytest -q` *(fails: No module named 'cv2', No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68be89b9f028832fbda08afba2909173