### PR TITLE
Handle None cm_per_pixel in resize_for_speed

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -260,8 +260,9 @@ def resize_for_speed(image, cm_per_pixel, max_size=1200):
     ----------
     image : numpy.ndarray
         Input BGR image.
-    cm_per_pixel : float
-        Conversion factor from pixels to centimeters at the current scale.
+    cm_per_pixel : float or None
+        Conversion factor from pixels to centimeters at the current scale. If
+        ``None``, the value is propagated unchanged.
     max_size : int, optional
         Target size for the longest side. Images smaller than this are
         returned unchanged. Defaults to ``1200``.
@@ -271,7 +272,8 @@ def resize_for_speed(image, cm_per_pixel, max_size=1200):
     tuple
         ``(resized_image, adjusted_cm_per_pixel)`` where the scale factor is
         applied equally to both dimensions and ``cm_per_pixel`` is divided by
-        that factor so real-world measurements remain accurate.
+        that factor so real-world measurements remain accurate. If
+        ``cm_per_pixel`` is ``None``, ``None`` is returned unchanged.
     """
 
     h, w = image.shape[:2]
@@ -283,6 +285,8 @@ def resize_for_speed(image, cm_per_pixel, max_size=1200):
     resized = cv2.resize(
         image, (int(w * scale), int(h * scale)), interpolation=cv2.INTER_AREA
     )
+    if cm_per_pixel is None:
+        return resized, None
     return resized, cm_per_pixel / scale
 
 

--- a/tests/test_resize_for_speed.py
+++ b/tests/test_resize_for_speed.py
@@ -14,3 +14,11 @@ def test_resize_for_speed_scales_and_adjusts():
     assert max(resized.shape[:2]) == 1200
     expected_cpp = 2.0 / (1200 / 2000)
     assert abs(cpp - expected_cpp) < 1e-6
+
+
+def test_resize_for_speed_none_cm_per_pixel():
+    """When ``cm_per_pixel`` is ``None`` the value is propagated unchanged."""
+    img = np.zeros((2000, 1000, 3), dtype=np.uint8)
+    resized, cpp = clothing.resize_for_speed(img, cm_per_pixel=None, max_size=1200)
+    assert max(resized.shape[:2]) == 1200
+    assert cpp is None


### PR DESCRIPTION
## Summary
- Allow `resize_for_speed` to accept `cm_per_pixel=None` and propagate it without adjustment
- Update docstring for `resize_for_speed` to document optional `cm_per_pixel`
- Add regression test ensuring `resize_for_speed` handles `cm_per_pixel=None`

## Testing
- `pytest tests/test_resize_for_speed.py::test_resize_for_speed_none_cm_per_pixel -q` *(fails: ModuleNotFoundError: No module named 'numpy')*
- `pip install numpy opencv-python-headless -q` *(fails: Could not find a version that satisfies the requirement numpy)*


------
https://chatgpt.com/codex/tasks/task_e_68be9462cf64832f94311ea55359d433