### PR TITLE
Fix marker scale calculation

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -171,6 +171,15 @@ def detect_marker(
         # rotated.
         box = cv2.boxPoints(best_rect)
 
+        # Calculate the average side length of the rectangle from the corner
+        # points.  ``minAreaRect`` may yield width/height values that are less
+        # stable under heavy rotation or perspective distortion, whereas the
+        # Euclidean distance between successive box points remains reliable.
+        side_lengths = [
+            np.linalg.norm(box[i] - box[(i + 1) % 4]) for i in range(4)
+        ]
+        side_length = float(np.mean(side_lengths))
+
         box_int = np.intp(box)
 
         rect_mask = np.zeros_like(gray)
@@ -187,6 +196,8 @@ def detect_marker(
 
         contrast = (outer_mean - inner_mean) / max(outer_mean, 1)
         if contrast >= 0.25:
+            if side_length > 0:
+                cm_per_pixel = marker_size_cm / side_length
 
             if debug:
                 cv2.drawContours(image, [box_int], 0, (0, 0, 255), 2)

--- a/tests/test_detect_marker_scale.py
+++ b/tests/test_detect_marker_scale.py
@@ -1,0 +1,38 @@
+import importlib.util
+from pathlib import Path
+
+import cv2
+import numpy as np
+
+
+def _load_module():
+    module_path = Path(__file__).resolve().parent.parent / "Clothing"
+    spec = importlib.util.spec_from_file_location("clothing", module_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _create_image():
+    img = np.full((200, 200, 3), 255, dtype=np.uint8)
+    cv2.rectangle(img, (75, 75), (125, 125), (0, 0, 0), -1)
+    return img
+
+
+def test_detect_marker_returns_scale():
+    clothing = _load_module()
+    img = _create_image()
+    cm_per_pixel = clothing.detect_marker(img.copy(), marker_size_cm=5.0)
+    assert cm_per_pixel is not None
+    assert abs(cm_per_pixel - 0.1) < 0.02
+
+
+def test_detect_marker_debug_returns_scale():
+    clothing = _load_module()
+    img = _create_image()
+    cm_per_pixel, debug = clothing.detect_marker(
+        img.copy(), marker_size_cm=5.0, debug=True
+    )
+    assert cm_per_pixel is not None
+    assert debug.shape == img.shape
+    assert np.any(debug != img)


### PR DESCRIPTION
## Summary
- compute marker side length to derive cm per pixel scale
- add basic tests ensuring marker detection returns a valid scale in normal and debug modes

## Testing
- `pip install -q numpy opencv-python-headless pillow` (fails: Could not find a version that satisfies the requirement numpy)
- `pytest tests/test_detect_marker_scale.py::test_detect_marker_returns_scale -q` (fails: ModuleNotFoundError: No module named 'cv2')


------
https://chatgpt.com/codex/tasks/task_e_68be95ff277c832f87a22614efce5373