### PR TITLE
Detect paper-like regions before garment measurement

### DIFF
--- a/Clothing
+++ b/Clothing
@@ -3,7 +3,7 @@ import numpy as np
 from PIL import Image, ImageDraw, ImageFont
 import os
 import numbers
-from measurements import measure_clothes
+from measurements import measure_clothes, NoGarmentDetectedError
 try:
     import pillow_heif
 except ImportError:  # pragma: no cover

--- a/tests/test_measurements.py
+++ b/tests/test_measurements.py
@@ -2,8 +2,9 @@ import os
 import importlib.util
 import numpy as np
 import cv2
+import pytest
 from sleeve import compute_sleeve_length
-from measurements import _split_sleeve_points
+from measurements import _split_sleeve_points, NoGarmentDetectedError
 
 # Load Clothing module from the script without extension
 MODULE_PATH = os.path.join(os.path.dirname(__file__), '..', 'Clothing')
@@ -124,5 +125,12 @@ def test_measure_clothes_chest_width_ignores_outlier():
     contour, measures = clothing.measure_clothes(img, cm_per_pixel=1.0)
     assert contour is not None
     assert abs(measures["身幅"] - 40) < 1.0
+
+
+def test_measure_clothes_rejects_paper():
+    img = np.zeros((200, 200, 3), dtype=np.uint8)
+    cv2.rectangle(img, (20, 20), (180, 180), (255, 255, 255), -1)
+    with pytest.raises(NoGarmentDetectedError):
+        clothing.measure_clothes(img, cm_per_pixel=1.0)
 
 


### PR DESCRIPTION
## Summary
- Detect paper-like foreground regions using edge density, colour variance and contour rectangularity heuristics
- Raise `NoGarmentDetectedError` when no garment is found and expose it via Clothing module
- Add regression test ensuring paper-like images are rejected

## Testing
- `python -m py_compile measurements.py tests/test_measurements.py Clothing`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*
- `pip install numpy opencv-python-headless -q` *(fails: Could not find a version that satisfies the requirement numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c048a13178832f9a2408bd22a14a89