### PR TITLE
Return garment contour from measure_clothes

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -455,7 +455,10 @@ def measure_clothes(
         "袖丈": sleeve_length * cm_per_pixel,
     }
 
-    return hull, measures
+    # ``hull`` is still used internally for deriving the bounding-box but the
+    # function now returns the original ``clothes_contour`` so callers can work
+    # with the precise garment outline rather than its convex hull.
+    return clothes_contour, measures
 
 
 __all__ = ["measure_clothes", "_split_sleeve_points", "NoGarmentDetectedError"]


### PR DESCRIPTION
## Summary
- `measure_clothes` now returns the original garment contour rather than its convex hull
- retain convex hull internally for bounding-box calculations

## Testing
- `pytest tests/test_measurements.py::test_measure_clothes_lengths_long -q` *(fails: No module named 'numpy')*


------
https://chatgpt.com/codex/tasks/task_e_68c04d2ec1fc832fa8f2e93f7337a927