### PR TITLE
Restore mask boundary after smoothing with dilation

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -194,6 +194,7 @@ def _smooth_mask_keep_shape(mask):
     ell3 = cv2.getStructuringElement(cv2.MORPH_ELLIPSE, (3, 3))
     m = cv2.morphologyEx(m, cv2.MORPH_CLOSE, ell5)  # 小穴埋め
     m = cv2.morphologyEx(m, cv2.MORPH_OPEN,  ell3)  # 粒ノイズ除去
+    m = cv2.dilate(m, ell3, 1)  # 開処理で削られた境界を少し復元
     return m
 # -----------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- ensure mask edges aren't overly eroded by re-dilating after opening

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68c193d56ca0832f8fe799a214c28d7a