### PR TITLE
Restore saturation-based garment contour filtering

### DIFF
--- a/measurements.py
+++ b/measurements.py
@@ -140,13 +140,19 @@ def _select_garment_contour(image_bgr, mask_bin):
         roi_mask = mask_bin[y : y + h, x : x + w] > 0
         lap_var = _laplacian_var(roi, roi_mask)
 
+        roi_hsv = hsv[y : y + h, x : x + w]
+        sat_roi = roi_hsv[..., 1]
+        sat_mean = sat_roi[roi_mask].mean() if roi_mask.any() else 0.0
+        if sat_mean > 60 and area < frame_area * 0.15:
+            continue
 
+        # 固定の除外規則（板/紙を弾く）
+        if rectangularity > 0.90 and (border or holes >= 1):
             continue
         if lap_var < 15.0 and rectangularity > 0.80:
             continue
 
-
-
+        candidates.append(c)
     if candidates:
         return max(candidates, key=cv2.contourArea)
     return max(cnts, key=cv2.contourArea)


### PR DESCRIPTION
## Summary
- Reinstate saturation-based filtering in `_select_garment_contour`
- Reapply contour exclusion rules for rectangular and low-texture regions

## Testing
- `python -m py_compile measurements.py`
- `pytest -q` *(fails: ModuleNotFoundError for cv2/numpy)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d798e3fc832face6a9765024b803