### PR TITLE
Fix type hint incompatible with Python 3.9

### DIFF
--- a/image_utils.py
+++ b/image_utils.py
@@ -1,4 +1,6 @@
 import os
+from typing import Optional
+
 import cv2
 import numpy as np
 from PIL import Image
@@ -21,7 +23,7 @@ def load_image(path):
         return cv2.imread(path)
 
 
-def _adaptive_kernel_size(img) -> int | None:
+def _adaptive_kernel_size(img) -> Optional[int]:
     """Return a kernel size based on the image's shorter side.
 
     Parameters
@@ -31,7 +33,7 @@ def _adaptive_kernel_size(img) -> int | None:
 
     Returns
     -------
-    int | None
+    Optional[int]
         ``3``, ``5`` or ``7`` based on the shorter dimension.  ``None`` if the
         size cannot be determined.
     """


### PR DESCRIPTION
## Summary
- use `Optional[int]` for `_adaptive_kernel_size` return type to avoid runtime evaluation of `int | None`
- update docstring and import typing.Optional

## Testing
- `python -m pytest -q` *(fails: No module named 'cv2'; No module named 'numpy'; No module named 'skimage')*

------
https://chatgpt.com/codex/tasks/task_e_68c6fc9257e8832f8a0bba8ad0e52b20