### PR TITLE
Add optional exports for thresholded images

### DIFF
--- a/script.py
+++ b/script.py
@@ -12,13 +12,17 @@ def main() -> None:
     parser.add_argument(
         "--output", default="output.png", help="path to save visualised result"
     )
+    parser.add_argument(
+        "--threshold-output",
+        help="optional path to save the raw threshold image used for segmentation",
+    )
     args = parser.parse_args()
 
     img = cv2.imread(args.image)
     if img is None:
         raise SystemExit("Failed to read input image")
 
-    mask = segment_garment(img)
+    mask = segment_garment(img, thresh_debug_path=args.threshold_output)
     meas = measure_garment(mask)
     vis = visualize(img, mask, meas)
     cv2.imwrite(args.output, vis)


### PR DESCRIPTION
## Summary
- Allow segmentation routines to optionally save the raw Otsu threshold image
- Expose threshold image paths in CLI helpers and debug utilities

## Testing
- `python -m py_compile measurements.py script.py smooth_cutout.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68c7c8d425bc832f9fd4d1922c3043e6