### PR TITLE
Unify image I/O and expose all threshold candidates

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,8 +1,10 @@
 """CLI entry point for garment segmentation and measurement."""
 
 import argparse
+import os
 import cv2
 
+from image_utils import load_image
 from measurements import segment_garment, measure_garment, visualize
 
 
@@ -14,18 +16,32 @@ def main() -> None:
     )
     parser.add_argument(
         "--threshold-output",
-        help="optional path to save the raw threshold image used for segmentation",
+        help="optional base path to save raw threshold candidates",
+    )
+    parser.add_argument(
+        "--debug-dir",
+        help="directory to save debug images like thresholds and mask",
     )
     args = parser.parse_args()
 
-    img = cv2.imread(args.image)
+    img = load_image(args.image)
     if img is None:
         raise SystemExit("Failed to read input image")
 
-    mask = segment_garment(img, thresh_debug_path=args.threshold_output)
+    thresh_path = args.threshold_output
+    if args.debug_dir:
+        os.makedirs(args.debug_dir, exist_ok=True)
+        if thresh_path is None:
+            thresh_path = os.path.join(args.debug_dir, "threshold.png")
+
+    mask = segment_garment(img, thresh_debug_path=thresh_path)
     meas = measure_garment(mask)
     vis = visualize(img, mask, meas)
     cv2.imwrite(args.output, vis)
+
+    if args.debug_dir:
+        cv2.imwrite(os.path.join(args.debug_dir, "mask.png"), mask)
+        cv2.imwrite(os.path.join(args.debug_dir, "measure.png"), vis)
 
     for k in ["shoulder_width", "body_width", "body_length", "sleeve_length"]:
         print(f"{k}: {meas.get(k, 0):.1f} px")


### PR DESCRIPTION
## Summary
- Save HSV, Otsu and inverted Otsu masks when segmenting garments
- Add HEIC-capable loader and debug outputs to CLI
- Consolidate smooth_cutout to single implementation with suffix-aware threshold export

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'cv2')*

------
https://chatgpt.com/codex/tasks/task_e_68c7cf189c50832f91fc10e58a0958c9